### PR TITLE
img: Add dark-mode logo (Fixes #4)

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -55,6 +55,7 @@ const config: Config = {
       logo: {
         alt: 'osbuild logo',
         src: 'img/logo.svg',
+        srcDark: 'img/logo_dark.svg',
       },
       items: [
         {

--- a/static/img/logo_dark.svg
+++ b/static/img/logo_dark.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 400 400"
+   style="enable-background:new 0 0 400 400;"
+   xml:space="preserve"
+   sodipodi:docname="logo_dark.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="2.9325"
+   inkscape:cx="199.8295"
+   inkscape:cy="200"
+   inkscape:window-width="2560"
+   inkscape:window-height="1371"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<path
+   d="M395.62,71.19L202.47,0.89c-1.6-0.58-3.35-0.58-4.95,0L4.38,71.19C2.95,71.71,2,73.07,2,74.59v250.83  c0,1.52,0.95,2.88,2.38,3.4l193.15,70.3c1.6,0.58,3.35,0.58,4.95,0l193.15-70.3c1.43-0.52,2.38-1.88,2.38-3.4V74.59  C398,73.07,397.05,71.71,395.62,71.19z M369.08,119c0,2.43-1.52,4.6-3.81,5.43l-162.81,59.28c-1.6,0.58-3.35,0.58-4.95,0  L64.68,135.34c-2.36-0.86-4.85,0.89-4.85,3.4v23.08c0,1.52,0.95,2.88,2.38,3.4l136.56,49.72c0.8,0.29,1.67,0.29,2.47,0l160.09-58.29  c3.77-1.37,7.76,1.42,7.76,5.43v80c0,2.43-1.52,4.6-3.81,5.43L202.47,306.8c-1.6,0.58-3.35,0.58-4.95,0L64.68,258.45  c-2.36-0.86-4.85,0.89-4.85,3.4v23.06c0,1.52,0.95,2.88,2.38,3.4l136.56,49.72c0.8,0.29,1.67,0.29,2.47,0l163-59.35  c2.36-0.86,4.85,0.89,4.85,3.4v21.56c0,2.43-1.52,4.6-3.81,5.43l-162.81,59.28c-1.6,0.58-3.35,0.58-4.95,0L34.72,309.06  c-2.29-0.83-3.81-3-3.81-5.43v-80c0-4.01,3.99-6.81,7.76-5.43l160.09,58.29c0.8,0.29,1.67,0.29,2.47,0l136.55-49.7  c1.43-0.52,2.38-1.88,2.38-3.4V200.3c0-2.51-2.49-4.26-4.85-3.4l-132.85,48.35c-1.6,0.58-3.35,0.58-4.95,0L34.72,185.98  c-2.29-0.83-3.81-3-3.81-5.43V96.35c0-2.43,1.52-4.6,3.81-5.43l162.81-59.26c1.6-0.58,3.35-0.58,4.95,0l162.81,59.26  c2.28,0.83,3.81,3,3.81,5.43V119z"
+   id="path1"
+   style="fill:#ffffff;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
This commit sets a dark-mode logo.
While our logo is an svg, the usual approach of resorting to a ThemedImage doesn't work.
Instead, the navbar's srcDark field needs to be set to a different logl.

See

- https://docusaurus.io/docs/next/markdown-features/assets#themed-images
- https://docusaurus.io/docs/api/themes/configuration#navbar-logo

Note: I'm aware that #4 refers to more than just the logo, but I feel the logo is the main pain point. All the other svgs are still legible.