### PR TITLE
index.module.css: Set hero banner bg color

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -9,6 +9,7 @@
   color: black;
   position: relative;
   overflow: hidden;
+  background-color: #B7C9B9;
   background-image: url(../../static/img/logo.jpg);
   background-size: cover;
 }


### PR DESCRIPTION
While this doesn't fix the slow loading of the hero banner background image, it does mitigate the horrible flicker by setting a background color that goes nicely with the picture.
Relates to #12