### PR TITLE
Reflect the distro names dot-notation in the documentation.

### DIFF
--- a/docs/on-premises/01-installation/managing-repositories.md
+++ b/docs/on-premises/01-installation/managing-repositories.md
@@ -164,8 +164,10 @@ Based on the system you want to build an image for, determine the name of a new 
 
 * Fedora 32 - `fedora-32.json`
 * Fedora 33 - `fedora-33.json`
-* RHEL 8.4 - `rhel-84.json`
-* RHEL 9.0 - `rhel-90.json`
+* RHEL 8.4 - `rhel-8.4.json` (`rhel-84.json` if you are using osbuild-composer prior to version 100)
+* RHEL 9.0 - `rhel-9.0.json` (`rhel-90.json` if you are using osbuild-composer prior to version 100)
+
+Note that **osbuild-composer prior to version 100** didn't use a dot `.` to separate major and minor release versions in the repository file names. New versions are backward compatible, so they will still read the old file names of distributions supported up to the version 100. However, going forward, it is strongly advised to use the new naming scheme. Future distribution versions won't be backward compatible (e.g. `rhel-100.json` won't work in the future for RHEL 10.0).
 
 Then, create the JSON file with the following structure (or copy the file from `/usr/share/osbuild-composer/` and modify its content):
 

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -32,11 +32,30 @@ new os. You can't build an OS image that differs from the host OS that Image Bui
 eg. A blueprint that will always build a Fedora 38 image, no matter what
 version is running on the host:
 
+Note that **osbuild-composer prior to version 100** didn't use a dot `.` to separate major and minor release versions in the distro name. New versions are backward compatible, so they will still accept the old distro names of distributions supported up to the version 100. However, going forward, it is strongly advised to use the new naming scheme. Future distribution versions won't be backward compatible (e.g. `rhel-100` won't work in the future for RHEL 10.0, but one will have to use `rhel-10.0`).
+
 ```toml
 name = "tmux"
 description = "tmux image with openssh"
 version = "1.2.16"
 distro = "fedora-38"
+
+[[packages]]
+name = "tmux"
+version = "*"
+
+[[packages]]
+name = "openssh-server"
+version = "*"
+```
+
+```toml
+name = "tmux"
+description = "tmux image with openssh"
+version = "1.2.16"
+# for osbuild-composer version < 100
+# distro = "rhel-84"
+distro = "rhel-8.4"
 
 [[packages]]
 name = "tmux"


### PR DESCRIPTION
Specifically:
 - Adjust the repository configuration file names to use the dot-notation.
 - Add note about the dot-notation in the "managing repositories" section, as well as to the blueprints section discussing the 'distro' key.