### PR TITLE
Add bootc to sync

### DIFF
--- a/docs/bootc/index.md
+++ b/docs/bootc/index.md
@@ -1,11 +1,14 @@
 # bootc-image-builder
 
-A container for deploying bootable container images.
+A container to create disk-images from [bootc](https://github.com/containers/bootc) container inputs.
+
+This tools allows to build and deploy disk-images from bootc container
+inputs.
 
 ## 🔨 Installation
 
 Have [podman](https://podman.io/) installed on your system. Either through your systems package manager if you're on
-Linux or through [Podman Desktop](https://podman.io/) if you are on Mac OS or Windows. If you want to run the resulting
+Linux or through [Podman Desktop](https://podman.io/) if you are on macOS or Windows. If you want to run the resulting
 virtual machine(s) or installer media you can use [qemu](https://www.qemu.org/).
 
 On macOS, the podman machine must be running in rootful mode:
@@ -23,21 +26,31 @@ $ podman machine start
 The following example builds a [Fedora ELN](https://docs.fedoraproject.org/en-US/eln/) bootable container into a QCOW2 image for the architecture you're running
 the command on.
 
+The `fedora-bootc:eln` base image does not include a default user. This example injects a [user configuration file](https://github.com/osbuild/bootc-image-builder/tree/main/README.md#-build-config)
+by adding a volume-mount for the local file as well as the `--config` flag to the bootc-image-builder container.
+
+The following command will create a QCOW2 disk image. First, create `./config.json` as described above to configure user access.
+
 ```
-mkdir output
 sudo podman run \
     --rm \
     -it \
     --privileged \
     --pull=newer \
     --security-opt label=type:unconfined_t \
+    -v $(pwd)/config.json:/config.json \
     -v $(pwd)/output:/output \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
+    --config /config.json \
     quay.io/centos-bootc/fedora-bootc:eln
 ```
 
 ### Running the resulting QCOW2 file on Linux (x86_64)
+
+A virtual machine can be launched using `qemu-system-x86_64` or with `virt-install` as shown below.
+
+#### qemu-system-x86_64
 
 ```
 qemu-system-x86_64 \
@@ -48,6 +61,17 @@ qemu-system-x86_64 \
     -bios /usr/share/OVMF/OVMF_CODE.fd \
     -serial stdio \
     -snapshot output/qcow2/disk.qcow2
+```
+
+#### virt-install
+
+```
+sudo virt-install \
+    --name fedora-bootc \
+    --vcpus 4 \
+    --memory 4096 \
+    --import --disk ./output/qcow2/disk.qcow2,format=qcow2 \
+    --os-variant fedora-eln
 ```
 
 ### Running the resulting QCOW2 file on macOS (aarch64)
@@ -86,15 +110,15 @@ Flags:
       --type string     image type to build [qcow2, ami] (default "qcow2")
 ```
 
-### Detailed description of positional flags 
+### Detailed description of optional flags
 
 | Argument     | Description                                                      | Default Value |
 |--------------|------------------------------------------------------------------|:-------------:|
-| **--config** | Path to a [build config](#-build-config)                         |       ❌       |
+| **--config** | Path to a [build config](https://github.com/osbuild/bootc-image-builder/tree/main/README.md#-build-config)                         |       ❌      |
 | --tls-verify | Require HTTPS and verify certificates when contacting registries |    `true`     |
-| **--type**   | [Image type](#-image-types) to build                             |    `qcow2`    |
+| **--type**   | [Image type](https://github.com/osbuild/bootc-image-builder/tree/main/README.md#-image-types) to build                             |    `qcow2`    |
 
-*💡 Tip: Flags in **bold** are the most important ones.* 
+*💡 Tip: Flags in **bold** are the most important ones.*
 
 ## 💾 Image types
 
@@ -104,6 +128,88 @@ The following image types are currently available via the `--type` argument:
 |-----------------------|---------------------------------------------------------------------------------------|
 | `ami`                 | [Amazon Machine Image](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) |
 | `qcow2` **(default)** | [QEMU](https://www.qemu.org/)                                                         |
+| `iso`                 | An unattended Anaconda installer that installs to the first disk found.               |
+
+## ☁️ Cloud uploaders
+
+### Amazon Machine Images (AMIs)
+
+#### Prerequisites
+
+In order to successfully import an AMI into your AWS account, you need to have the [vmimport service role](https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html) configured on your account.
+
+#### Flags
+
+AMIs can be automatically uploaded to AWS by specifying the following flags:
+
+| Argument       | Description                                                      |
+|----------------|------------------------------------------------------------------|
+| --aws-ami-name | Name for the AMI in AWS                                          |
+| --aws-bucket   | Target S3 bucket name for intermediate storage when creating AMI |
+| --aws-region   | Target region for AWS uploads                                    |
+
+*Notes:*
+- *These flags must all be specified together. If none are specified, the AMI is exported to the output directory.*
+- *The bucket must already exist in the selected region, bootc-image-builder will not create it if it is missing.*
+- *The output volume is not needed in this case. The image is uploaded to AWS and not exported.*
+
+#### AWS credentials file
+If you already have a credentials file (usually in `$HOME/.aws/credentials`) you need to forward the
+directory to the container
+
+For example:
+ ```
+ $ sudo podman run \
+  --rm \
+  -it \
+  --privileged \
+  --pull=newer \
+  --security-opt label=type:unconfined_t \
+  -v $HOME/.aws:/root/.aws:ro \
+  --env AWS_PROFILE=default \
+  quay.io/centos-bootc/bootc-image-builder:latest \
+  --type ami \
+  --aws-ami-name fedora-bootc-ami \
+  --aws-bucket fedora-bootc-bucket \
+  --aws-region us-east-1 \
+  quay.io/centos-bootc/fedora-bootc:eln
+```
+
+Notes:
+ - *you can also inject **ALL** your AWS configuration parameters with `--env AWS_*`*
+
+see the [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) for more information about other environment variables
+
+#### AWS credentials via environment
+AWS credentials can be specified through two environment variables:
+| Variable name         | Description                                                                                                         |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------|
+| AWS_ACCESS_KEY_ID     | AWS access key associated with an IAM account.                                                                      |
+| AWS_SECRET_ACCESS_KEY | Specifies the secret key associated with the access key. This is essentially the "password" for the access key.     |
+
+Those **should not** be specified with `--env` as plain value, but you can silently hand them over with `--env AWS_*` or
+save these variables in a file and pass them using the `--env-file` flag for `podman run`.
+
+For example:
+```
+$ cat aws.secrets
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+$ sudo podman run \
+  --rm \
+  -it \
+  --privileged \
+  --pull=newer \
+  --security-opt label=type:unconfined_t \
+  --env-file=aws.secrets \
+  quay.io/centos-bootc/bootc-image-builder:latest \
+  --type ami \
+  --aws-ami-name fedora-bootc-ami \
+  --aws-bucket fedora-bootc-bucket \
+  --aws-region us-east-1 \
+  quay.io/centos-bootc/fedora-bootc:eln
+```
 
 ## 💽 Volumes
 
@@ -121,7 +227,7 @@ A build config is a JSON file with customizations for the resulting image. A pat
 
 As an example, let's show how you can add a user to the image:
 
-Firstly create a file `output/config.json` and put the following content into it:
+Firstly create a file `./config.json` and put the following content into it:
 
 ```json
 {
@@ -129,8 +235,9 @@ Firstly create a file `output/config.json` and put the following content into it
     "customizations": {
       "user": [
         {
-          "name": "foo",
-          "password": "bar",
+          "name": "alice",
+          "password": "bob",
+          "key": "ssh-rsa AAA ... user@email.com",
           "groups": [
             "wheel"
           ]
@@ -150,10 +257,11 @@ sudo podman run \
     --privileged \
     --pull=newer \
     --security-opt label=type:unconfined_t \
+    -v $(pwd)/config.json:/config.json \
     -v $(pwd)/output:/output \
     quay.io/centos-bootc/bootc-image-builder:latest \
     --type qcow2 \
-    --config /output/config.json \
+    --config /config.json \
     quay.io/centos-bootc/fedora-bootc:eln
 ```
 
@@ -163,8 +271,9 @@ Possible fields:
 
 | Field      | Use                                        | Required |
 |------------|--------------------------------------------|:--------:|
-| `name`     | Name of the user                           |    ✅     |
+| `name`     | Name of the user                           |    ✅    |
 | `password` | Unencrypted password                       |    No    |
+| `key     ` | Public SSH key contents                    |    No    |
 | `groups`   | An array of secondary to put the user into |    No    |
 
 Example:
@@ -175,6 +284,7 @@ Example:
     {
       "name": "alice",
       "password": "bob",
+      "key": "ssh-rsa AAA ... user@email.com",
       "groups": [
         "wheel",
         "admins"
@@ -182,6 +292,38 @@ Example:
     }
   ]
 }
+```
+
+## Building
+
+To build the container locally you can run
+```shell
+sudo podman build --tag bootc-image-builder .
+```
+NOTE: running already the `podman build` as root avoids problems later as we need to run the building
+of the image as root anyway
+
+### Accessing the system
+
+With a virtual machine launched with the above [virt-install](https://github.com/osbuild/bootc-image-builder/tree/main/README.md#virt-install) example, access the system with
+
+```
+ssh -i /path/to/private/ssh-key alice@ip-address
+```
+
+Note that if you do not provide a password for the provided user, `sudo` will not work unless passwordless sudo
+is configured. The base image `quay.io/centos-bootc/fedora-bootc:eln` does not configure passwordless sudo.
+This can be configured in a derived bootc container by including the following in a Containerfile.
+
+```
+FROM quay.io/centos-bootc/fedora-bootc:eln
+ADD wheel-passwordless-sudo /etc/sudoers.d/wheel-passwordless-sudo
+```
+
+The contents of the file `$(pwd)/wheel-passwordless-sudo` should be
+
+```
+%wheel ALL=(ALL) NOPASSWD: ALL
 ```
 
 ## 📊 Project
@@ -194,7 +336,7 @@ Example:
 
 ### Contributing
 
-Please refer to the [developer guide](../developer-guide/index) to learn about our
+Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our
 workflow, code style and more.
 
 ## 🗄️ Repository

--- a/readme-list
+++ b/readme-list
@@ -1,3 +1,4 @@
+bootc-image-builder/main/README.md:docs/bootc/index.md
 osbuild/main/README.md:docs/developer-guide/02-projects/osbuild/index.md
 images/main/test/README.md:docs/developer-guide/02-projects/images/testing.md
 images/main/docs/developer/README.md:docs/developer-guide/02-projects/images/index.md

--- a/scripts/pull_readmes.py
+++ b/scripts/pull_readmes.py
@@ -52,6 +52,12 @@ def parse_markdown_and_replace_links(file_path, baseurl):
                             lambda match: replace_relative_links(match, baseurl),
                             markdown_content, flags=re.DOTALL)
 
+    # Drop angel brackets around hyperlinks because DocuSaurus doesn't like them
+    angel_bracket_pattern = r'<(http.*?)>'
+    parsed_content = re.sub(angel_bracket_pattern,
+                            lambda match: match.group(1),
+                            parsed_content, flags=re.DOTALL)
+
     return parsed_content
 
 


### PR DESCRIPTION
Update the bootc page and sync it daily from now on.

Also extend the script to drop angel brackets around URLs, because DocuSaurus fails to compile when they're in markdown files and we often have them in the READMEs.