### PR TITLE
pull-readmes: Drop angel brackets around email links

### DIFF
--- a/scripts/pull_readmes.py
+++ b/scripts/pull_readmes.py
@@ -54,11 +54,11 @@ def parse_markdown_and_replace_links(file_path, baseurl):
                             lambda match: replace_relative_links(match, baseurl),
                             markdown_content, flags=re.DOTALL)
 
-    # Drop angel brackets around hyperlinks because DocuSaurus doesn't like them
-    angel_bracket_pattern = r'<(http.*?)>'
+    # Drop angel brackets around hyperlinks/email links because DocuSaurus doesn't like them
+    angel_bracket_pattern = r'<(http.+?|.+@.+)>'
     parsed_content = re.sub(angel_bracket_pattern,
                             lambda match: match.group(1),
-                            parsed_content, flags=re.DOTALL)
+                            parsed_content)
 
     return parsed_content
 


### PR DESCRIPTION
The previous regular expression only took http links into account, but recently we've also had links to mailing lists wrapped in angel brackets.
It makes sense to account for this and remove the brackets around email links.

You can see the failed run from earlier today here: https://github.com/osbuild/osbuild.github.io/actions/runs/7897746553/job/21553844143#step:6:29

Here's the code that broke the parser: https://github.com/osbuild/bootc-image-builder/blob/main/README.md?plain=1#L342