### PR TITLE
blueprint: document systemd customization failure

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -576,6 +576,8 @@ An *optional* object containing the following attributes:
 - `enabled` an *optional* list of strings containing services to be enabled.
 - `disabled` an *optional* list of strings containing services to be disabled.
 
+If a service enabled or disabled through the corresponding attributes does not exist in the image that is being built then this customization will fail and the build will fail as a result.
+
 <Tabs values={tabValues} >
 <TabItem value="on-premises" >
 ```toml


### PR DESCRIPTION
When a service that does not exist on the image being built the build fails. Mention this.