### PR TITLE
Update url of the developer guide

### DIFF
--- a/docs/bootc/index.md
+++ b/docs/bootc/index.md
@@ -344,7 +344,7 @@ The contents of the file `$(pwd)/wheel-passwordless-sudo` should be
 
 ### Contributing
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our
+Please refer to the [developer guide](https://www.osbuild.org/docs/developer-guide/index) to learn about our
 workflow, code style and more.
 
 ## 🗄️ Repository

--- a/docs/developer-guide/02-projects/image-builder/HACKING.md
+++ b/docs/developer-guide/02-projects/image-builder/HACKING.md
@@ -1,6 +1,6 @@
 # Image Builder contributing guide
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our workflow, code style and more.
+Please refer to the [developer guide](https://www.osbuild.org/docs/developer-guide/index) to learn about our workflow, code style and more.
 
 ## Running the project locally
 

--- a/docs/developer-guide/02-projects/images/index.md
+++ b/docs/developer-guide/02-projects/images/index.md
@@ -17,7 +17,7 @@ Images
 
 ### Contributing
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/developer-guide.html) to learn about our workflow, code style and more.
+Please refer to the [developer guide](https://www.osbuild.org/docs/developer-guide/index) to learn about our workflow, code style and more.
 
 The build-requirements for Fedora and rpm-based distributions are:
 - `gpgme-devel`, `btrfs-progs-devel`, `device-mapper-devel`

--- a/docs/developer-guide/02-projects/osbuild-composer/CONTRIBUTING.md
+++ b/docs/developer-guide/02-projects/osbuild-composer/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 First of all, thank you for taking the time to contribute to osbuild-composer.
 In this document you will find information that can help you with your
 contribution.
-For more information feel free to read our [developer guide](https://www.osbuild.org/guides/developer-guide/developer-guide.html).
+For more information feel free to read our [developer guide](https://www.osbuild.org/docs/developer-guide/index).
 
 ### Running from sources
 

--- a/docs/developer-guide/02-projects/osbuild-composer/index.md
+++ b/docs/developer-guide/02-projects/osbuild-composer/index.md
@@ -27,7 +27,7 @@ instance, includes a
 
 #### Contributing
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our workflow, code style and more.
+Please refer to the [developer guide](https://www.osbuild.org/docs/developer-guide/index) to learn about our workflow, code style and more.
 
 ### About
 

--- a/docs/developer-guide/02-projects/osbuild/index.md
+++ b/docs/developer-guide/02-projects/osbuild/index.md
@@ -29,7 +29,7 @@ of the pipeline description, and more.
 
 ### Contributing
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our workflow, code style and more.
+Please refer to the [developer guide](https://www.osbuild.org/docs/developer-guide/index) to learn about our workflow, code style and more.
 
 ## Requirements
 

--- a/docs/on-premises/00-overview/index.md
+++ b/docs/on-premises/00-overview/index.md
@@ -19,6 +19,6 @@ There are two frontends that you can use to communicate with osbuild-composer:
 
 This guide contains instructions on installing `osbuild-composer` service and its basic usage.
 
-If you want to fix a typo, or even contribute new content, the sources for this webpage are hosted in [osbuild/guides GitHub repository](https://github.com/osbuild/guides/).
+If you want to fix a typo, or even contribute new content, the sources for this webpage are hosted in [osbuild/osbuild.github.io GitHub repository](https://github.com/osbuild/osbuild.github.io).
 
 For Red Hatters, the internal guides can be found [here](https://osbuild.pages.redhat.com/internal-guides/).


### PR DESCRIPTION
The developer guides have moved to a new url, fix all the references to the old one.