### PR TITLE
ghactions: Protect generated dev-guide from changes

### DIFF
--- a/.github/workflows/protect-readmes.yml
+++ b/.github/workflows/protect-readmes.yml
@@ -1,0 +1,22 @@
+name: Protect generated developer guide
+# Ensure that READMEs are not inadvertently changed in a pull request as those changes
+# would be dropped on the next CI run
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  protect-developer-guide:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        run: |
+          python3 scripts/protect_readmes.py readme-list

--- a/scripts/protect_readmes.py
+++ b/scripts/protect_readmes.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Small script to verify the READMEs that get pulled in automatically don't get changed in a pull request
+
+import argparse
+import subprocess
+import os
+
+
+def file_has_changed(filename):
+    """
+    Verify that the file has not been changed.
+    """
+    if not os.path.isfile(filename):
+        print(f"Error: File not found: {filename}")
+        exit(1)
+
+    try:
+        output = subprocess.check_output(['git', 'diff', '--exit-code', 'HEAD..origin/main', '--', filename])
+        # If the output is empty, it means the file has not been changed
+        return bool(output.strip())
+    except subprocess.CalledProcessError:
+        # If git diff returns a non-zero exit code, it means the file has been changed
+        return True
+
+
+def main():
+    """
+    Main function to parse command-line arguments and execute the script.
+    """
+    parser = argparse.ArgumentParser(description='Parse a Markdown file and replace relative links with absolute links.')
+    parser.add_argument('input_file', help='Path to the input file containing source and target paths')
+
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.input_file):
+        print(f"Error: File not found: {args.input_file}")
+        exit(1)
+
+    file_changed = ""
+
+    with open(args.input_file, 'r') as input_file:
+        for line in input_file:
+            # Skip comments
+            if line.strip().startswith("#"):
+                continue
+
+            source, targetpath = line.strip().split(':')
+
+            if source and targetpath:
+                if file_has_changed(targetpath):
+                    url = source.replace('/main','/blob/main')
+                    file_changed += f"\n * {targetpath} (synced from 'http://github.com/osbuild/{url}')"
+
+    if file_changed != "":
+        print(f"⛔ Error: These files cannot be modified manually:{file_changed}")
+        exit(1)
+    else:
+        print("✅ No automatically pulled-in files have been changed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Test whether a pull request introduces changes in one of the files that get pulled in automatically on a schedule.

This breaks the previous workflow of adding in the new readmes when they get added to the `readme-list` file (see e.g. https://github.com/osbuild/osbuild.github.io/pull/40/files). That workflow was nice because it allowed the reviewer to see the changes ahead of time.
OTOH it prevents pull requests like this one: https://github.com/osbuild/osbuild.github.io/pull/43