### PR TITLE
User guide/BP ref: fix formatting when selecting distro

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -76,20 +76,6 @@ version = "*"
 name = "openssh-server"
 version = "*"
 ```
-</TabItem>
-<TabItem value="hosted">
-```json
-{
-  "image_name": "tmux",
-  "image_description": "tmux image with openssh",
-  "distribution": "fedora-38",
-  "customizations": {
-    "packages": ["tmux", "openssh-server"]
-  }
-}
-```
-</TabItem>
-</Tabs>
 
 ```toml
 name = "tmux"
@@ -107,6 +93,31 @@ version = "*"
 name = "openssh-server"
 version = "*"
 ```
+</TabItem>
+<TabItem value="hosted">
+```json
+{
+  "image_name": "tmux",
+  "image_description": "tmux image with openssh",
+  "distribution": "fedora-38",
+  "customizations": {
+    "packages": ["tmux", "openssh-server"]
+  }
+}
+```
+
+```json
+{
+  "image_name": "tmux",
+  "image_description": "tmux image with openssh",
+  "distribution": "rhel-8.4",
+  "customizations": {
+    "packages": ["tmux", "openssh-server"]
+  }
+}
+```
+</TabItem>
+</Tabs>
 
 ## Content
 


### PR DESCRIPTION
The PR adding tabs showing the on-prem and hosted versions of BP customizations and various other options landed somewhat at the same time as the PR amending documentation to reflect the dot-notation. As a result, one TOML snipped added by the dot-notation PR was not properly formatted for the on-prem vs hosted version.

Fix this bug.