### PR TITLE
developer-guide: Add weldr-client docs

### DIFF
--- a/readme-list
+++ b/readme-list
@@ -24,3 +24,6 @@ cockpit-composer/main/README.md:docs/developer-guide/02-projects/cockpit-compose
 cockpit-composer/main/test/README.md:docs/developer-guide/02-projects/cockpit-composer/testing.md
 # RPM Repo
 rpmrepo/main/README.md:docs/developer-guide/02-projects/rpmrepo/index.md
+# Weldr-client
+weldr-client/main/README.md:docs/developer-guide/02-projects/composer-cli/index.md
+weldr-client/main/HACKING.md:docs/developer-guide/02-projects/composer-cli/HACKING.md

--- a/scripts/protect_readmes.py
+++ b/scripts/protect_readmes.py
@@ -12,8 +12,8 @@ def file_has_changed(filename):
     Verify that the file has not been changed.
     """
     if not os.path.isfile(filename):
-        print(f"Error: File not found: {filename}")
-        exit(1)
+        print(f"⚠️ Warning: File not found: {filename}"
+              "  This likely means that a new file is added to the sync.")
 
     try:
         output = subprocess.check_output(['git', 'diff', '--exit-code', 'HEAD..origin/main', '--', filename])


### PR DESCRIPTION
Since the GitHub Action that protects the developer guide against changes would fail, I cannot show the results of pulling in the additional `README.md` and `HACKING.md` files.

This can be tested locally quite easily by calling:
```
python3 scripts/pull_readmes.py readme-list
npm start
```