### PR TITLE
index: Fix padding in mobile view

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -42,7 +42,7 @@ const FeatureList: FeatureItem[] = [
 function Feature({title, description, link}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
-      <div className="text--center padding-horiz--md">
+      <div className={"text--center padding-horiz--md " + styles.featureBlock}>
         <Heading as="h3">{title}</Heading>
         <p>{description}</p>
         <div className={styles.buttons}>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -1,11 +1,15 @@
 .features {
   display: flex;
   align-items: center;
-  padding: 2rem 0;
+  padding-bottom: 2rem;
   width: 100%;
 }
 
 .featureSvg {
   height: 200px;
   width: 200px;
+}
+
+.featureBlock {
+  padding-top: 2rem;
 }


### PR DESCRIPTION
In mobile view (or just narrow browser window) there was no padding between the feature blocks