### PR TITLE
blueprint-reference: correct /usr/local paths

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -631,7 +631,7 @@ The service names are systemd service units. You may specify any systemd unit fi
 
 You can use blueprint customizations to create custom files and directories in the image. When using the custom files and directories customization, the following rules apply:
 
-- The path must be an absolute path and must be under `/etc`, `/root` or `/usr/local`.
+- The path must be an absolute path and must be under `/etc`, `/root`, `/usr/local/bin` or `/usr/local/sbin`.
 - There must be no duplicate paths of the same directory.
 - There must be no duplicate paths of the same file.
 


### PR DESCRIPTION
@ondrejbudai pointed out in https://github.com/osbuild/osbuild.github.io/pull/59 that paths were not correct.

I am not changing the fact that only files are allowed tho, I do not have enough know-how to elaborate this and it looks like a bigger change of the docs.