### PR TITLE
user-guide/01-blueprint-reference: fix links to partitioning

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1047,7 +1047,7 @@ in the repository configuration. **GPG keys are not imported to the RPM database
 
 ### Partitioning mode 🔵 🟤 {#partitioning-mode}
 
-_See the section of the guide on [Partitioning](partitioning) for more details._
+_See the section of the guide on [Partitioning](./07-partitioning.md) for more details._
 
 The `customizations.partitioning_mode` variable can be used to select how the
 disk image will be partitioned. `auto-lvm` will use raw unless there are one or
@@ -1085,7 +1085,7 @@ partitioning_mode = "lvm"
 
 ### Filesystems 🔵 🟤 🟣 {#filesystems}
 
-_See the section of the guide on [Partitioning](partitioning) for more details._
+_See the section of the guide on [Partitioning](./07-partitioning.md) for more details._
 
 The blueprints can be extended to provide filesytem support. Currently the `mountpoint` and minimum partition `minsize` can be set. On `RHEL-8`, custom mountpoints are supported only since version `8.5`. For older `RHEL` versions, only the root mountpoint, `/`, is supported, the size argument being an alias for the image size.
 


### PR DESCRIPTION
the link only worked when the user is on
`/docs/user-guide/blueprint-reference#partitioning-mode` but not on
`/docs/user-guide/blueprint-reference/#partitioning-mode` (trailing slash)

with this fix the link is processed by docusaurus and works in both cases see
https://docusaurus.io/docs/markdown-features/links