### PR TITLE
docs/user-guide/01-blueprint-reference: fix chapter level of fips

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1351,7 +1351,7 @@ data = "<json-tailoring-file-contents>"
 </Tabs>
 
 
-#### FIPS 🔵 🟤 {#fips}
+### FIPS 🔵 🟤 {#fips}
 
 Enables/disables the system FIPS mode (disabled by default).
 Currently only `edge-raw-image`, `edge-installer`, `edge-simplified-installer`,


### PR DESCRIPTION
should this be visible in the overview and the same level as other customizations?
currently it's below "OpenSCAP" 🤔