### PR TITLE
docs: fix link to release overview

### DIFF
--- a/docs/on-premises/00-overview/index.md
+++ b/docs/on-premises/00-overview/index.md
@@ -5,7 +5,7 @@ Image Builder is available in various distributions:
 - [CentOS Stream](https://www.centos.org/centos-stream/)
 - [Red Hat Enterprise Linux (RHEL)](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux)
 
-You can see an overview of [which version is released where here](./release-overview).
+You can see an overview of [which version is released where here](./02-release-overview.md).
 
 ![Diagram](./image-builder-on-premises.svg)
 


### PR DESCRIPTION
This is another instance of the issue addressed in #104