### PR TITLE
footer: add dicussions link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -114,6 +114,10 @@ const config: Config = {
           title: 'Community',
           items: [
             {
+              label: 'Discussions',
+              href: 'https://github.com/orgs/osbuild/discussions',
+            },
+            {
               label: 'Matrix',
               href: 'https://matrix.to/#/#image-builder:fedoraproject.org',
             },


### PR DESCRIPTION
This patch is supposed to add a new link to the footer. Let’s start growing our community by providing a single place.