### PR TITLE
config: enable toml syntax highlighting

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -138,6 +138,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['toml'],
     },
   } satisfies Preset.ThemeConfig,
   plugins: [


### PR DESCRIPTION
docusaurus doesn't enable toml highlighting by default, let's enable it

See the following links for the list of languages enabled by default: https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23

Before:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/df6ec553-8811-4eaa-9642-71e58c6c599d">


After:
<img width="391" alt="image" src="https://github.com/user-attachments/assets/e216ecc7-c174-4234-92dc-e33511add1ca">
