### PR TITLE
Fix typos in example blueprints

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -538,7 +538,7 @@ expiredate = 12345
 ```
 </TabItem>
 <TabItem value="bootc" >
-```
+```toml
 [[customizations.user]]
 name = "alice"
 password = "bob"

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1258,33 +1258,33 @@ The examples below are illustrative but not comprehensive. The [Partitioning](./
 <Tabs values={tabValuesOnPremBootc} >
 <TabItem value="on-premises" >
 ```toml
-[[customization.disk.partitions]]
+[[customizations.disk.partitions]]
 type = "plain"
 label = "data"
 mountpoint = "/data"
 fs_type = "ext4"
 minsize = "50 GiB"
 
-[[customization.disk.partitions]]
+[[customizations.disk.partitions]]
 type = "lvm"
 name = "mainvg"
 minsize = "20 GiB"
 
-[[customization.disk.partitions.logical_volumes]]
+[[customizations.disk.partitions.logical_volumes]]
 name = "rootlv"
 mountpoint = "/"
 label = "root"
 fs_type = "ext4"
 minsize = "2 GiB"
 
-[[customization.disk.partitions.logical_volumes]]
+[[customizations.disk.partitions.logical_volumes]]
 name = "homelv"
 mountpoint = "/home"
 label = "home"
 fs_type = "ext4"
 minsize = "2 GiB"
 
-[[customization.disk.partitions.logical_volumes]]
+[[customizations.disk.partitions.logical_volumes]]
 name = "swaplv"
 fs_type = "swap"
 minsize = "1 GiB"
@@ -1298,7 +1298,7 @@ minsize = "1 GiB"
 <TabItem value="bootc" >
 ```json
 {
-  "customization": {
+  "customizations": {
     "disk": {
       "partitions": [
         {

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1296,48 +1296,37 @@ minsize = "1 GiB"
 ```
 </TabItem>
 <TabItem value="bootc" >
-```json
-{
-  "customizations": {
-    "disk": {
-      "partitions": [
-        {
-          "type": "plain",
-          "label": "data",
-          "mountpoint": "/data",
-          "fs_type": "ext4",
-          "minsize": "50 GiB"
-        },
-        {
-          "type": "lvm",
-          "name": "mainvg",
-          "minsize": "20 GiB",
-          "logical_volumes": [
-            {
-              "name": "rootlv",
-              "mountpoint": "/",
-              "label": "root",
-              "fs_type": "ext4",
-              "minsize": "2 GiB"
-            },
-            {
-              "name": "homelv",
-              "mountpoint": "/home",
-              "label": "home",
-              "fs_type": "ext4",
-              "minsize": "2 GiB"
-            },
-            {
-              "name": "swaplv",
-              "fs_type": "swap",
-              "minsize": "1 GiB"
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
+```toml
+[[customizations.disk.partitions]]
+type = "plain"
+label = "data"
+mountpoint = "/data"
+fs_type = "ext4"
+minsize = "50 GiB"
+
+[[customizations.disk.partitions]]
+type = "lvm"
+name = "mainvg"
+minsize = "20 GiB"
+
+[[customizations.disk.partitions.logical_volumes]]
+name = "rootlv"
+mountpoint = "/"
+label = "root"
+fs_type = "ext4"
+minsize = "2 GiB"
+
+[[customizations.disk.partitions.logical_volumes]]
+name = "homelv"
+mountpoint = "/home"
+label = "home"
+fs_type = "ext4"
+minsize = "2 GiB"
+
+[[customizations.disk.partitions.logical_volumes]]
+name = "swaplv"
+fs_type = "swap"
+minsize = "1 GiB"
 ```
 </TabItem>
 </Tabs>
@@ -1664,21 +1653,14 @@ disable = [
 ```
 </TabItem>
 <TabItem value="bootc" >
-```json
-{
-  "customizations": {
-    "installer": {
-      "modules": {
-        "enable": [
-          "org.fedoraproject.Anaconda.Modules.Localization"
-        ],
-        "disable": [
-          "org.fedoraproject.Anaconda.Modules.Users"
-        ]
-      }
-    }
-  }
-}
+```toml
+[customizations.installer.modules]
+enable = [
+    "org.fedoraproject.Anaconda.Modules.Localization",
+]
+disable = [
+    "org.fedoraproject.Anaconda.Modules.Users",
+]
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Fix typos in example blueprints
- fix typo in customization**s**
- align on using `toml` for `bootc`
- add correct syntax highlighting