### PR TITLE
Update bootc docs

### DIFF
--- a/docs/bootc/index.md
+++ b/docs/bootc/index.md
@@ -36,7 +36,7 @@ $ podman machine start
 
 ## ✍ Prerequisites
 
-The package `osbuild-selinux` or equivalent osbuild SELinux policies must be installed in the system running
+If you are on a system with SELinux enforced: The package `osbuild-selinux` or equivalent osbuild SELinux policies must be installed in the system running
 `bootc-image-builder`.
 
 ## 🚀 Examples


### PR DESCRIPTION
SELinux policies only have to be installed on systems where SELinux is actually enforced. This is e.g. not the case on a Debian system.