### PR TITLE
user-guide: fix the link to the repo customizations

### DIFF
--- a/docs/user-guide/02-repository-customizations.md
+++ b/docs/user-guide/02-repository-customizations.md
@@ -17,8 +17,6 @@ To install a third-party package at build time, it is necessary to enable the re
 to the image and will not make the repositories available to users on the system after the image has been built. For further information on how to install and configure `osbuild-composer`
 to use custom repositories for installing third-party packages, continue reading [here](../../on-premises/installation/managing-repositories).
 
-https://osbuild.org/docs/on-premises/installation/managing-repositories
-
 
 ## 2. Save repository configurations
 In the second scenario, to make third-party repository configurations persistent and make the repositories available to users on the system, one would use the blueprint `custom repository`

--- a/docs/user-guide/02-repository-customizations.md
+++ b/docs/user-guide/02-repository-customizations.md
@@ -15,7 +15,9 @@ This could lead to the following desired usecases:
 ## 1. Install a third-party package
 To install a third-party package at build time, it is necessary to enable the required third-party repository as a payload repository. This will not save any of the repository configurations
 to the image and will not make the repositories available to users on the system after the image has been built. For further information on how to install and configure `osbuild-composer`
-to use custom repositories for installing third-party packages, continue reading [here](../on-premises/installation/managing-repositories).
+to use custom repositories for installing third-party packages, continue reading [here](../../on-premises/installation/managing-repositories).
+
+https://osbuild.org/docs/on-premises/installation/managing-repositories
 
 
 ## 2. Save repository configurations


### PR DESCRIPTION
Prior this commit, the link pointed at:
https://osbuild.org/docs/user-guide/on-premises/installation/managing-repositories

The correct link is this one:
https://osbuild.org/docs/on-premises/installation/managing-repositories