### PR TITLE
config: set trailingSlash to false

### DIFF
--- a/docs/developer-guide/01-general/testing-strategy/index.md
+++ b/docs/developer-guide/01-general/testing-strategy/index.md
@@ -109,4 +109,4 @@ The cloud-cleaner binary was created to clean up all artifacts (like images, but
 
 ### RPM Repository Snapshots
 
-In order to provide a stable base for the tests, the maintainer team created [the RPMRepo project](../../projects/rpmrepo) that periodically snapshots repositories of selected distributions.
+In order to provide a stable base for the tests, the maintainer team created [the RPMRepo project](../projects/rpmrepo) that periodically snapshots repositories of selected distributions.

--- a/docs/hosted/architecture/index.md
+++ b/docs/hosted/architecture/index.md
@@ -21,7 +21,7 @@ The architecture documents in this section comply with the AppSRE contract.
 
 ## How to contribute
 
-Our [developer guide](../../developer-guide/index) is a great starting point to learn about our workflow, code style and more!
+Our [developer guide](../developer-guide/index) is a great starting point to learn about our workflow, code style and more!
 
 If you want to contribute to our frontend or backend, here are guides on how to get the respective stack set up for development:
  * [image-builder-frontend](https://github.com/RedHatInsights/image-builder-frontend#frontend-development)
@@ -45,15 +45,15 @@ If you want to contribute to our frontend or backend, here are guides on how to 
 * 🟢 Deployment metadata is open. [[1]](https://github.com/osbuild/osbuild-composer/blob/main/templates/composer.yml) [[2]](https://github.com/osbuild/image-builder/blob/main/templates/image-builder.yml)
 #### 🟢 Contribution workflow
 * 🟢 External contributors can follow the same workflow as team members.
-* 🟢 [The workflow is publicly documented.](../../developer-guide/general/workflow)
+* 🟢 [The workflow is publicly documented.](../developer-guide/general/workflow)
 * 🟢 Regular contributors can trigger CI.
 * 🟢 External contributions are eagerly reviewed.
 #### 🟠 Issue tracking and planning
 * 🟢 The issue tracker is public. [[1]](https://github.com/osbuild) [[2]](https://issues.redhat.com/issues/?jql=project%20%3D%20COMPOSER%20or%20(project%20%3D%20HMS%20AND%20component%20in%20(%22Image%20Builder%22)))
 * 🟠 The roadmap is public. [[1]](https://github.com/orgs/osbuild/projects)
 #### 🟢 Documentation
-* 🟢 [User documentation is public.](../../user-guide/introduction)
-* 🟢 [Developer documentation is public.](../../developer-guide/index)
+* 🟢 [User documentation is public.](../user-guide/introduction)
+* 🟢 [Developer documentation is public.](../developer-guide/index)
 #### 🟠 Communication
 * 🟢 [There is a public mailinglist.](mailto:image-builder@redhat.com)
 * 🔴 There are public meetings.

--- a/docs/on-premises/02-commandline/index.md
+++ b/docs/on-premises/02-commandline/index.md
@@ -74,7 +74,7 @@ logs
 logs/osbuild.log
 ```
 
-From the example output above, the resulting tarball contains not only the `qcow2` image, but also a `JSON` file, which is the osbuild manifest (see the [Developer Guide](../../developer-guide/index) for more details), and a directory with logs.
+From the example output above, the resulting tarball contains not only the `qcow2` image, but also a `JSON` file, which is the osbuild manifest (see the [Developer Guide](../developer-guide/index) for more details), and a directory with logs.
 
 For more options, see the `help` text for `composer-cli`:
 

--- a/docs/user-guide/04-uploading-cloud-images/index.md
+++ b/docs/user-guide/04-uploading-cloud-images/index.md
@@ -4,9 +4,9 @@
 
 The following targets are supported:
 
-- [AWS](./uploading-to-aws)
-- [AWS S3](./uploading-to-aws-s3)
-- [Azure](./uploading-to-azure)
-- [GCP](./uploading-to-gcp)
-- [Oracle Cloud](./uploading-to-oci)
-- [Generic S3](./uploading-to-generic-s3)
+- [AWS](uploading-cloud-images/uploading-to-aws)
+- [AWS S3](uploading-cloud-images/uploading-to-aws-s3)
+- [Azure](uploading-cloud-images/uploading-to-azure)
+- [GCP](uploading-cloud-images/uploading-to-gcp)
+- [Oracle Cloud](uploading-cloud-images/uploading-to-oci)
+- [Generic S3](uploading-cloud-images/uploading-to-generic-s3)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,5 +1,5 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
+import { themes as prismThemes } from 'prism-react-renderer';
+import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import { execSync } from 'child_process';
 
@@ -29,6 +29,7 @@ const config: Config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'osbuild', // Usually your GitHub org/user name.
   projectName: 'osbuild.github.io', // Usually your repo name.
+  trailingSlash: false,
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
On certain pages we get broken links. See e.g.
https://osbuild.org/docs/user-guide/repository-customizations/
and try to click on "continue reading here" (under the first item).
It gives you 404. Weirdly, this works just fine when running npm start.

I looked into the docusaurus docs, and it seems like it's recommended
to set trailingSlash to either false or true when deploying to Github
pages. I chose false, because that's what's used in the example.
Let's hope it fixes the 404 issue.

See https://docusaurus.io/docs/deployment#docusaurusconfigjs-settings