### PR TITLE
Use path-based relative links, and turn on trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,19 @@ $ make build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
+### Guidelines
+
+When using relative links, please make sure they are path-based, and not URL-based.
+
+❌ Bad:
+```markdown
+[Blueprint](../overview/blueprint)
+```
+
+✅ Good:
+```markdown
+[Blueprint](../01-overview/blueprint.md)
+```
+
+This follows Docusaurus' guidance, see [their docs](https://docusaurus.io/docs/markdown-features/links) for more information.

--- a/docs/developer-guide/01-general/testing-strategy/index.md
+++ b/docs/developer-guide/01-general/testing-strategy/index.md
@@ -109,4 +109,4 @@ The cloud-cleaner binary was created to clean up all artifacts (like images, but
 
 ### RPM Repository Snapshots
 
-In order to provide a stable base for the tests, the maintainer team created [the RPMRepo project](../projects/rpmrepo) that periodically snapshots repositories of selected distributions.
+In order to provide a stable base for the tests, the maintainer team created [the RPMRepo project](../../02-projects/index.md) that periodically snapshots repositories of selected distributions.

--- a/docs/developer-guide/02-projects/osbuild/deprecation.md
+++ b/docs/developer-guide/02-projects/osbuild/deprecation.md
@@ -1,7 +1,7 @@
 # Deprecation
 
-`osbuild` gives the guarantee that a given [manifest](./manifest) will produce the same image as long as any external sources remain available in any future versions of `osbuild`.
+`osbuild` gives the guarantee that a given [manifest](./manifest.md) will produce the same image as long as any external sources remain available in any future versions of `osbuild`.
 
-## Modules 
+## Modules
 
-As `osbuild` guarantees that the same manifest will produce the same image [modules](./modules) cannot change their schema or behavior after introduction. They can only be expanded upon.
+As `osbuild` guarantees that the same manifest will produce the same image [modules](./modules/index.md) cannot change their schema or behavior after introduction. They can only be expanded upon.

--- a/docs/hosted/architecture/index.md
+++ b/docs/hosted/architecture/index.md
@@ -21,7 +21,7 @@ The architecture documents in this section comply with the AppSRE contract.
 
 ## How to contribute
 
-Our [developer guide](../developer-guide/index) is a great starting point to learn about our workflow, code style and more!
+Our [developer guide](../../developer-guide/00-index.md) is a great starting point to learn about our workflow, code style and more!
 
 If you want to contribute to our frontend or backend, here are guides on how to get the respective stack set up for development:
  * [image-builder-frontend](https://github.com/RedHatInsights/image-builder-frontend#frontend-development)
@@ -45,15 +45,15 @@ If you want to contribute to our frontend or backend, here are guides on how to 
 * 🟢 Deployment metadata is open. [[1]](https://github.com/osbuild/osbuild-composer/blob/main/templates/composer.yml) [[2]](https://github.com/osbuild/image-builder/blob/main/templates/image-builder.yml)
 #### 🟢 Contribution workflow
 * 🟢 External contributors can follow the same workflow as team members.
-* 🟢 [The workflow is publicly documented.](../developer-guide/general/workflow)
+* 🟢 [The workflow is publicly documented.](../../developer-guide/01-general/workflow.md)
 * 🟢 Regular contributors can trigger CI.
 * 🟢 External contributions are eagerly reviewed.
 #### 🟠 Issue tracking and planning
 * 🟢 The issue tracker is public. [[1]](https://github.com/osbuild) [[2]](https://issues.redhat.com/issues/?jql=project%20%3D%20COMPOSER%20or%20(project%20%3D%20HMS%20AND%20component%20in%20(%22Image%20Builder%22)))
 * 🟠 The roadmap is public. [[1]](https://github.com/orgs/osbuild/projects)
 #### 🟢 Documentation
-* 🟢 [User documentation is public.](../user-guide/introduction)
-* 🟢 [Developer documentation is public.](../developer-guide/index)
+* 🟢 [User documentation is public.](../../user-guide/00-introduction.md)
+* 🟢 [Developer documentation is public.](../../developer-guide/00-index.md)
 #### 🟠 Communication
 * 🟢 [There is a public mailinglist.](mailto:image-builder@redhat.com)
 * 🔴 There are public meetings.

--- a/docs/on-premises/00-overview/01-basic-concepts.md
+++ b/docs/on-premises/00-overview/01-basic-concepts.md
@@ -3,11 +3,11 @@
 `osbuild-composer` works with a concept of **blueprints**. A blueprint is a description of the final **image** and its **customizations**. A **customization** can be:
 * an additional RPM package
 * enabled service
-* custom kernel command line parameter, and many others. See [Blueprint](../../user-guide/blueprint-reference) reference for more details.
+* custom kernel command line parameter, and many others. See [Blueprint](../../user-guide/01-blueprint-reference.md) reference for more details.
 
 An **image** is defined by its blueprint and **image type**, which is for example `qcow2` (QEMU Copy On Write disk image) or `AMI` (Amazon Machine Image).
 
-Finally, `osbuild-composer` also supports **upload targets**, which are cloud providers where an image can be stored after it is built. See the [Uploading cloud images](../../user-guide/uploading-cloud-images/) section for more details.
+Finally, `osbuild-composer` also supports **upload targets**, which are cloud providers where an image can be stored after it is built. See the [Uploading cloud images](../../user-guide/04-uploading-cloud-images/index.md) section for more details.
 
 ## Example blueprint
 

--- a/docs/on-premises/02-commandline/index.md
+++ b/docs/on-premises/02-commandline/index.md
@@ -74,7 +74,7 @@ logs
 logs/osbuild.log
 ```
 
-From the example output above, the resulting tarball contains not only the `qcow2` image, but also a `JSON` file, which is the osbuild manifest (see the [Developer Guide](../developer-guide/index) for more details), and a directory with logs.
+From the example output above, the resulting tarball contains not only the `qcow2` image, but also a `JSON` file, which is the osbuild manifest (see the [Developer Guide](../../developer-guide/00-index.md) for more details), and a directory with logs.
 
 For more options, see the `help` text for `composer-cli`:
 

--- a/docs/user-guide/00-introduction.md
+++ b/docs/user-guide/00-introduction.md
@@ -2,7 +2,7 @@
 
 With the Image Builder tool, you can create customized system images. Image builder automatically handles the setup details for each output type and is therefore easier to use and faster to work with than manual methods of image creation. You can access the Image Builder functionalities by using the [command-line interface](https://osbuild.org/docs/on-premises/commandline/), or the [Web UI](https://osbuild.org/docs/on-premises/installation/#web-ui) interface. With Image Builder, you can create system images that are prepared for deployment, including system images prepared for [clouds](https://osbuild.org/docs/user-guide/uploading-cloud-images/), and also images optimized for deployment on [edge](https://osbuild.org/docs/on-premises/commandline/building-ostree-images) servers.
 
-This user guide refers primarily to the on [premises version of Image Builder](../on-premises/overview). While many of the concepts are transferable to the service, at this point please refer to Red Hat's official documentation.
+This user guide refers primarily to the on [premises version of Image Builder](../on-premises/00-overview/index.md). While many of the concepts are transferable to the service, at this point please refer to Red Hat's official documentation.
 
 ### Image Builder terminology
 

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -288,7 +288,7 @@ containers = [
 </TabItem>
 </Tabs>
 
-To access protected container resources a `containers-auth.json(5)` file can be used, see [Container registry credentials](../on-premises/installation/container-auth).
+To access protected container resources a `containers-auth.json(5)` file can be used, see [Container registry credentials](../on-premises/01-installation/container-auth.md).
 
 
 ## Customizations
@@ -1056,7 +1056,7 @@ Third-party repositories are supported by the blueprint customizations. A reposi
 An optional `filename` argument can be set, otherwise the repository will be saved using the the repository ID, i.e. `/etc/yum.repos.d/<repo-id>.repo`.
 
 Please note custom repositories **cannot be used at build time to install third-party packages**. These customizations are used to save and enable third-party repositories on the image. For more information, or if you
-wish to install a package from a third-party repository, please continue reading [here](repository-customizations).
+wish to install a package from a third-party repository, please continue reading [here](./02-repository-customizations.md).
 
 The following example can be used to create a third-party repository:
 
@@ -1357,7 +1357,7 @@ From `RHEL 8.7` & `RHEL 9.1` support has been added for `OpenSCAP` build-time re
 
 If the datastream parameter is not provided, `osbuild-composer` will now provide a sensible default based on the selected distro.
 
-Please see [the OpenSCAP page](oscap-remediation) for the list of available security profiles.
+Please see [the OpenSCAP page](./03-oscap-remediation.md) for the list of available security profiles.
 
 <Tabs values={tabValues} >
 <TabItem value="on-premises" >

--- a/docs/user-guide/02-repository-customizations.md
+++ b/docs/user-guide/02-repository-customizations.md
@@ -15,15 +15,15 @@ This could lead to the following desired usecases:
 ## 1. Install a third-party package
 To install a third-party package at build time, it is necessary to enable the required third-party repository as a payload repository. This will not save any of the repository configurations
 to the image and will not make the repositories available to users on the system after the image has been built. For further information on how to install and configure `osbuild-composer`
-to use custom repositories for installing third-party packages, continue reading [here](../on-premises/installation/managing-repositories).
+to use custom repositories for installing third-party packages, continue reading [here](../on-premises/01-installation/managing-repositories.md).
 
 
 ## 2. Save repository configurations
 In the second scenario, to make third-party repository configurations persistent and make the repositories available to users on the system, one would use the blueprint `custom repository`
-configurations to enable this. The repository will be configured and saved to `/etc/yum.repos.d` as a `.repo` file. GPG keys are not imported at build time, but are imported when first 
-installing a third-party package from the desired repository. You can find the blueprint reference for custom repositories [here](./blueprint-reference).
+configurations to enable this. The repository will be configured and saved to `/etc/yum.repos.d` as a `.repo` file. GPG keys are not imported at build time, but are imported when first
+installing a third-party package from the desired repository. You can find the blueprint reference for custom repositories [here](./01-blueprint-reference.md).
 
 ## 3. Install a third-party package and save configurations
-In this case it is necessary to use a combination of payload repositories and custom repositories in order to achieve the desired outcome. This will ensure that the package is installed during 
+In this case it is necessary to use a combination of payload repositories and custom repositories in order to achieve the desired outcome. This will ensure that the package is installed during
 build time and the repository configuration is saved to disk for future use. If the user only needs the package or the configuration file, they can use the appropriate repository type to achieve
 their goal.

--- a/docs/user-guide/03-oscap-remediation.md
+++ b/docs/user-guide/03-oscap-remediation.md
@@ -39,7 +39,7 @@ datastream = "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
 
 
 
-See the [Supported profiles](./oscap-remediation#supported-profiles) table for supported profiles.
+See the [Supported profiles](./03-oscap-remediation.md#supported-profiles) table for supported profiles.
 
 `osbuild-composer` will then generate the necessary configurations for the `osbuild` stage based on the user
 customizations. Additionally, two packages will be added to the image, `openscap-scanner` (the `OpenSCAP` tool)

--- a/docs/user-guide/04-uploading-cloud-images/index.md
+++ b/docs/user-guide/04-uploading-cloud-images/index.md
@@ -4,9 +4,9 @@
 
 The following targets are supported:
 
-- [AWS](uploading-cloud-images/uploading-to-aws)
-- [AWS S3](uploading-cloud-images/uploading-to-aws-s3)
-- [Azure](uploading-cloud-images/uploading-to-azure)
-- [GCP](uploading-cloud-images/uploading-to-gcp)
-- [Oracle Cloud](uploading-cloud-images/uploading-to-oci)
-- [Generic S3](uploading-cloud-images/uploading-to-generic-s3)
+- [AWS](./01-uploading-to-aws.md)
+- [AWS S3](./02-uploading-to-aws-s3.md)
+- [Azure](./03-uploading-to-azure.md)
+- [GCP](./04-uploading-to-gcp.md)
+- [Oracle Cloud](./05-uploading-to-oci.md)
+- [Generic S3](./06-uploading-to-generic-s3.md)

--- a/docs/user-guide/05-uploading-to-registry.md
+++ b/docs/user-guide/05-uploading-to-registry.md
@@ -26,4 +26,4 @@ password = "PASSWORD"  # optional, password to use
 
 Instead of specifying `username` and `password` directly, a central
 `containers-auth.json(5)` file can be used, see
-[Container registry credentials](../on-premises/installation/container-auth).
+[Container registry credentials](../on-premises/01-installation/container-auth.md).

--- a/docs/user-guide/07-partitioning.md
+++ b/docs/user-guide/07-partitioning.md
@@ -10,11 +10,11 @@ In addition to the above, certain directories have hard-coded minimum sizes whic
 
 ## Using Filesystem customizations
 
-When using the [Filesystem customizations](blueprint-reference#filesystems), the final partition table of an image built with image builder is determined by a combination of the following:
+When using the [Filesystem customizations](01-blueprint-reference.md#filesystems), the final partition table of an image built with image builder is determined by a combination of the following:
 1. The base partition table for a given image type.
 2. The relevant blueprint customizations:
-    1. [Partitioning mode](blueprint-reference#partitioning-mode).
-    2. [Filesystem customizations](blueprint-reference#filesystems).
+    1. [Partitioning mode](01-blueprint-reference.md#partitioning-mode).
+    2. [Filesystem customizations](01-blueprint-reference.md#filesystems).
 3. The image size parameter of the build request.
     1. On the command line, this is the `--size` argument of the `composer-cli compose start` command.
     2. In the service, this is the `size` parameter of an `image_request`.
@@ -30,11 +30,11 @@ The partitioning mode controls how the partition table is modified from the imag
 - `raw` will not convert any partition to LVM or Btrfs.
 - `lvm` will always convert the partition that contains the root mountpoint `/` to an LVM Volume Group and create a root Logical Volume. Any extra mountpoints, except `/boot`, will be added to the Volume Group as new Logical Volumes.
 - `btrfs` will convert the partition that contains the root mountpoint `/` to a Btrfs volume and create a root subvolume. Any extra mountpoints, except `/boot`, will be added to the Btrfs volume as new Btrfs subvolumes.
-- `auto-lvm` is the default mode and will convert a raw partition table to an LVM-based one if and only if new mountpoints are defined in the [filesystems customization](blueprint-reference#filesystems). See also the [Mountpoints](#mountpoints) section below.
+- `auto-lvm` is the default mode and will convert a raw partition table to an LVM-based one if and only if new mountpoints are defined in the [filesystems customization](01-blueprint-reference.md#filesystems). See also the [Mountpoints](#mountpoints) section below.
 
 #### Mountpoints
 
-New filesystems and minimum partition sizes are defined using the [filesystems customization](blueprint-reference#filesystems) in the blueprint. By default, if new mountpoints are created, a partition table is automatically converted to LVM (see [Partitioning modes](#partitioning-modes) above).
+New filesystems and minimum partition sizes are defined using the [filesystems customization](01-blueprint-reference.md#filesystems) in the blueprint. By default, if new mountpoints are created, a partition table is automatically converted to LVM (see [Partitioning modes](#partitioning-modes) above).
 
 #### Image size
 
@@ -57,7 +57,7 @@ The combination above will create a disk with a partition table of the desired s
 
 ## Using Disk customizations
 
-When using the [Disk customizations](blueprint-reference#disk), the partition table can be described almost entirely using the blueprint. The customizations have the following structure:
+When using the [Disk customizations](01-blueprint-reference.md#disk), the partition table can be described almost entirely using the blueprint. The customizations have the following structure:
 - `partitions`: At the top level is a list of partitions.
   - `type`: Each partition has a `type`, which should be one of `plain`, `lvm`, or `btrfs`. If the `type` is not set, it defaults to `plain`. The rest of the required and optional properties of the partition depend on the `type`.
     - `plain`: A plain partition is a partition with a filesystem. It supports the following properties:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -29,7 +29,7 @@ const config: Config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'osbuild', // Usually your GitHub org/user name.
   projectName: 'osbuild.github.io', // Usually your repo name.
-  trailingSlash: false,
+  trailingSlash: true,
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
config: turn trailingSlash on
    
Apparently, Google indexes are website mostly with trailing slashes, so let's enable them to limit the overall breakeage from this change.
    
This should hopefully fix all issues with trailing slashes once and forever.
    
See https://www.google.com/search?q=site%3Aosbuild.org
and https://bjornlu.com/blog/trailing-slash-for-frameworks#which-is-better

---

docs: make all relative links path-based
    
We used a lot of relative URL paths before. This has two issues:
 - the relative URLs are depending on the trailingSlash config
 - the links don't work in the GitHub interface
 - autocomplete in vscode cannot resolve them
    
Let's switch to file paths instead. This fixes all issues above. Docusaurus then happily resolves the paths to URL ones when compiling the website.
    
See this link for more info:
https://docusaurus.io/docs/markdown-features/links