### PR TITLE
`image-installer` format is missing from the user guide

### DIFF
--- a/docs/user-guide/00-introduction.md
+++ b/docs/user-guide/00-introduction.md
@@ -44,6 +44,7 @@ Image Builder can create images in multiple output formats shown in the followin
 | IoT Simplified Installer | iot-simplified-installer | .iso      | 
 | IoT AMI | iot-ami | .ami      | 
 | IoT VMDK | iot-vmdk | .vmdk      | 
+| Installer | image-installer | iso     | 
 | Installer | live-installer | iso     | 
 | Oracle Cloud Infrastructure | oci     | .qcow2      | 
 


### PR DESCRIPTION
I simply added a missing format to the table on the `Introduction` page of the `User Guide`.