### PR TITLE
bp-reference: use a multiline string for the custom file example

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -881,7 +881,10 @@ path = "/etc/foobar"
 mode = "0644"
 user = "root"
 group = "root"
-data = "Hello world!"
+data = """
+Hello world!
+This is how you make a multiline string.
+"""
 ```
 </TabItem>
 <TabItem value="hosted" >
@@ -893,7 +896,7 @@ data = "Hello world!"
         "mode": "0644",
         "user": "root",
         "group": "root",
-        "data": "Hello world!"
+        "data": "Hello world!\nThis is how you make a multiline string.\n"
       }
     ]
   }


### PR DESCRIPTION
I expect most people to need a multiline string, so let's have one as the example.