### PR TITLE
`user-guide/08-firstboot`: add missing closing `quote`

### DIFF
--- a/docs/user-guide/08-firstboot.md
+++ b/docs/user-guide/08-firstboot.md
@@ -108,7 +108,7 @@ data = """
 """
 
 [[customizations.files]]
-path = "/etc/systemd/system/custom-first-boot.service
+path = "/etc/systemd/system/custom-first-boot.service"
 data = """
 [Unit]
 ConditionPathExists=/usr/local/sbin/custom-first-boot


### PR DESCRIPTION
Hi :wave:,

I added the missing closing quote to the example manifest in the section of the [Firstboot script](https://osbuild.org/docs/user-guide/firstboot/#firstboot-systemd-unit-with-ansible) page in the `User Guide`.