### PR TITLE
`user-guide/08-firstboot`: add missing `quotes` to the `mode` value

### DIFF
--- a/docs/user-guide/08-firstboot.md
+++ b/docs/user-guide/08-firstboot.md
@@ -83,7 +83,7 @@ name = "linux-system-roles"
 
 [[customizations.files]]
 path = "/usr/local/sbin/custom-first-boot"
-mode = 0774
+mode = "0774"
 data = """
 #!/usr/bin/ansible-playbook -i localhost,
 


### PR DESCRIPTION
Hi 👋,

Yesterday, I tried to create an RHEL image by adding custom files using `[[customizations.files]]`, based on the sample script from the [Firstboot script](https://osbuild.org/docs/user-guide/firstboot/#firstboot-systemd-unit-with-ansible) page. I ran into an issue where another set of quotes was missing in the doc.

The manifest that triggers the exception:

```toml
[[customizations.files]]
path = "/usr/local/sbin/custom-first-boot"
mode = 0774
```

Output:

```
TASK [./ansible-role-guest : Push rhel-kvm-host blueprint to Image Builder] ****
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "composer-cli blueprints push /tmp/rhel-kvm-host.toml", "delta": "0:00:00.007445", "end": "2025-02-04 08:01:22.777196", "msg": "non-zero return code", "rc": 1, "start": "2025-02-04 08:01:22.769751", "stderr": "ERROR: BlueprintsError: 400 Bad Request: The browser (or proxy) sent a request that this server could not understand: toml: line 70 (last key \"customizations.files.mode\"): Invalid integer \"0755\": cannot have leading zeroes", "stderr_lines": ["ERROR: BlueprintsError: 400 Bad Request: The browser (or proxy) sent a request that this server could not understand: toml: line 70 (last key \"customizations.files.mode\"): Invalid integer \"0755\": cannot have leading zeroes"], "stdout": "", "stdout_lines": []}
```

And the one that works:

```toml
[[customizations.files]]
path = "/usr/local/sbin/custom-first-boot"
mode = "0774"
```