### PR TITLE
Add note on OpenSCAP for ostree based images

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1362,6 +1362,9 @@ If the datastream parameter is not provided, `osbuild-composer` will now provide
 
 Please see [the OpenSCAP page](./03-oscap-remediation.md) for the list of available security profiles.
 
+> :warning: **Note**
+Building OpenSCAP hardened images for `ostree` based images not supported.
+
 <Tabs values={tabValues} >
 <TabItem value="on-premises" >
 ```toml

--- a/docs/user-guide/03-oscap-remediation.md
+++ b/docs/user-guide/03-oscap-remediation.md
@@ -49,6 +49,9 @@ customizations. Additionally, two packages will be added to the image, `openscap
 The remediation stage assumes that the
 `scap-security-guide` will be used for the datastream. This package is installed on the image by default. If another datastream is desired, add the necessary package to the blueprint and specify the path to the datastream in the oscap config.
 
+> :warning: **Note**
+Building OpenSCAP hardened images for `ostree` based images not supported.
+
 ## Supported profiles
 
 The supported profiles are distro specific, see below:

--- a/docs/user-guide/03-oscap-remediation.md
+++ b/docs/user-guide/03-oscap-remediation.md
@@ -1,6 +1,6 @@
 # OpenSCAP Remediation
 
-`osbuild-composer` provides the ability to build security hardened images using the [OpenSCAP] tool. 
+`osbuild-composer` provides the ability to build security hardened images using the [OpenSCAP] tool.
 This feature is available for `RHEL 8.7` (& above) and `RHEL 9.1` (& above).
 
 [OpenSCAP]: https://github.com/OpenSCAP/openscap/blob/maint-1.3/docs/manual/manual.adoc
@@ -13,7 +13,7 @@ boot of the image.
 
 ## Build-time Remediation
 
-To solve that limitation, `osbuild-composer` uses the build-time remediation: an [osbuild stage] runs the `OpenSCAP` tool to search for vulnerabilities on the filesystem tree while the image is being built. The `OpenSCAP` tool runs 
+To solve that limitation, `osbuild-composer` uses the build-time remediation: an [osbuild stage] runs the `OpenSCAP` tool to search for vulnerabilities on the filesystem tree while the image is being built. The `OpenSCAP` tool runs
 the standard evaluation for the given profile and applies the remediations to the image. This process enables the user to build a more completely
 hardened image compared to running the remediation on a live system.
 
@@ -26,7 +26,7 @@ profile_id = "xccdf_org.ssgproject.content_profile_standard"
 datastream = "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
 ```
 
-`osbuild-composer` exposes to fields for the user to customize in the image blueprints: 
+`osbuild-composer` exposes to fields for the user to customize in the image blueprints:
 
   1) The path to the `datastream` instructions. Usually in the `/usr/share/xml/scap/ssg/content/` directory
   2) The `profile_id` for the desired security standard


### PR DESCRIPTION
Adding a line to state that building `ostree` based hardened images is not supported.