### PR TITLE
test_pull_readmes: fix tests

### DIFF
--- a/scripts/test_pull_readmes.py
+++ b/scripts/test_pull_readmes.py
@@ -1,6 +1,6 @@
 import re
 import unittest
-from pull_readmes import resolve_dirs, replace_relative_links, RELATIVE_LINK_PATTERN
+from utils import resolve_dirs, replace_relative_links, RELATIVE_LINK_PATTERN
 
 
 class TestResolveDirs(unittest.TestCase):


### PR DESCRIPTION
As the functions are now moved to `utils.py`
the test needs to take it from there.