### PR TITLE
new-distro-testing: update steps for new distribution testing

### DIFF
--- a/docs/developer-guide/01-general/testing-strategy/new-distro-testing.md
+++ b/docs/developer-guide/01-general/testing-strategy/new-distro-testing.md
@@ -9,7 +9,7 @@ This document describes how to enable testing for a new distribution, or a new v
 5. Add support for the distribution in [osbuild/ci-image-refresh-bot (internal only)](https://gitlab.cee.redhat.com/osbuild/ci-image-refresh-bot).
 6. Run the `ci-image-refresh-bot`, so that it updates image placeholders in [osbuild/gitlab-ci-terraform](https://github.com/osbuild/gitlab-ci-terraform).
 7. Add new repository definitions and distribution support (if needed) in [osbuild/images](https://github.com/osbuild/images/).
-8. Update `.gitlab-ci.yml` runners and `Schutzfile` snapshots for the new distribution and `gitlab-ci-terraform` ref in [osbuild/osbuild](https://github.com/osbuild/osbuild) to build `osbuild` RPMs for the new distribution.
-9. Update the `images` ref in `Schutzfile` in [osbuild/osbuild](https://github.com/osbuild/osbuild) and add new distribution runners to test manifests in GitLab CI.
-10. Add new repository definitions in [osbuild/osbuild-composer](https://github.com/osbuild/osbuild-composer).
+8. Update unit test runners in GitHub actions (if needed) in [osbuild/images](https://github.com/osbuild/images/).
+9. Update `.gitlab-ci.yml` runners and `Schutzfile` snapshots for the new distribution and `gitlab-ci-terraform` ref in [osbuild/osbuild](https://github.com/osbuild/osbuild) to build `osbuild` RPMs for the new distribution.
+10. Update the `images` ref in `Schutzfile` in [osbuild/osbuild](https://github.com/osbuild/osbuild) and add new distribution runners to test manifests in GitLab CI.
 11. Update `.gitlab-ci.yml` runners and `Schutzfile` snapshots for the new distribution and the `osbuild` ref in [osbuild/osbuild-composer](https://github.com/osbuild/osbuild-composer).


### PR DESCRIPTION
1. Add step for updating the runners for the unit tests that run in GitHub actions for osbuild/images.
2. Remove the mention of repository definitions in osbuild/composer. They only need to be defined in osbuild/images now, which is covered by step 7.