### PR TITLE
Publish available image type descriptions in the upstream documentation (HMS-7044)

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -37,6 +37,16 @@ jobs:
         run: |
           make pull-image-builder
 
+      - name: Install podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Pull image descriptions
+        working-directory: ./osbuild.github.io
+        run: |
+          make pull-image-descriptions
+
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,28 @@ pull-image-builder: ## pull the image-builder-cli documentation
 pull-osbuild-modules: ## pull the documentation of the osbuild modules 
 	python3 scripts/pull_osbuild_modules.py
 
+# Pull image descriptions for subset of supported distributions
+# Documentation is generated in docs/user-guide/09-image-definitions/
+# This generates documentation for:
+# - Fedora 41+
+# - Latest RHEL-10 GA version - 10.0
+# - Latest RHEL-9 GA version - 9.6
+# - Latest RHEL-8 GA version - 8.10
+# - All CentOS Stream versions
+# - All AlmaLinux versions
+.PHONY: pull-image-descriptions
+pull-image-descriptions:
+	python3 scripts/pull_image_descriptions.py \
+		--distro-filter "fedora-4[1-9]" \
+		--distro-filter "rhel-10.0" \
+		--distro-filter "rhel-9.6" \
+		--distro-filter "rhel-8.10" \
+		--distro-filter "centos-*" \
+		--distro-filter "almalinux-*" \
+		--distro-filter "almalinux_kitten-*"
+
 .PHONY: generate
-generate: pull-readmes pull-osbuild-modules ## generate all external content
+generate: pull-readmes pull-osbuild-modules pull-image-descriptions ## generate all external content
 
 .PHONY: install-dependencies
 install-dependencies: ## install all dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -578,13 +578,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -879,17 +880,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -916,23 +919,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2111,12 +2116,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2135,13 +2138,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2165,12 +2169,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -5719,9 +5724,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6499,9 +6505,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7548,15 +7555,12 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.0.1.tgz",
-      "integrity": "sha512-b2tdzTurEIbwRh+mKrEcaWfu1wgb8J1hVsgREg7FFiecWwK/PhO8X0kyc+0bIcKNtD4sqxIdNoRy6/p/TvECEA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.4.0.tgz",
+      "integrity": "sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "is-plain-obj": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "@types/estree": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/remcohaszing"
@@ -7658,9 +7662,10 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7681,7 +7686,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -7696,6 +7701,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/content-disposition": {
@@ -7723,9 +7732,10 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/express/node_modules/range-parser": {
       "version": "1.2.1",
@@ -9009,9 +9019,10 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -11927,11 +11938,12 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -12057,15 +12069,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -12585,9 +12598,10 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -14208,9 +14222,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15392,9 +15406,10 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }

--- a/scripts/pull_image_descriptions.py
+++ b/scripts/pull_image_descriptions.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+
+import argparse
+import fnmatch
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+CONTAINER_IMAGE = "ghcr.io/osbuild/image-builder-cli:latest"
+GENERATION_DATE = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
+TARGET_DIR = pathlib.Path(__file__).parent.parent / "docs" / "user-guide" / "09-image-descriptions"
+
+
+def run_command(cmd: List[str]) -> Tuple[bool, str, str]:
+    """
+    Run a command and return success status, stdout, and stderr.
+    """
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return True, result.stdout, result.stderr
+    except subprocess.CalledProcessError as e:
+        return False, e.stdout, e.stderr
+
+
+def pull_container_image() -> bool:
+    """
+    Pull the latest image-builder-cli container image.
+    """
+    print("Pulling latest container image...")
+    pull_cmd = ["sudo", "podman", "pull", CONTAINER_IMAGE]
+    success, _, stderr = run_command(pull_cmd)
+    if not success:
+        print(f"Warning: Failed to pull container image: {stderr}")
+        return False
+    print("Container image pulled successfully")
+    return True
+
+
+def get_container_version() -> str:
+    """
+    Get the version/ref of the image-builder-cli container.
+    """
+    # Get the image ID and digest information
+    cmd = ["sudo", "podman", "images", CONTAINER_IMAGE, "--format", "{{.Repository}}:{{.Tag}}@{{.Digest}}"]
+    success, stdout, _ = run_command(cmd)
+    if success and stdout.strip():
+        return stdout.strip()
+
+    # Fallback to just the image ID if digest is not available
+    fallback_cmd = ["sudo", "podman", "images", CONTAINER_IMAGE, "--format", "{{.Repository}}:{{.Tag}} ({{.ID}})"]
+    success, stdout, _ = run_command(fallback_cmd)
+    if success and stdout.strip():
+        return stdout.strip()
+
+    return f"{CONTAINER_IMAGE} (unknown)"
+
+
+def list_images() -> Dict:
+    """
+    Get list of all supported images using list-images command.
+
+    The returned dict structure is
+    {
+        "distro_name": {
+            "arch_name": [image_type_name, image_type_name, ...],
+            "arch_name": [image_type_name, image_type_name, ...],
+        }
+    }
+    """
+    cmd = ["sudo", "podman", "run", "--rm", "--privileged", CONTAINER_IMAGE, "list-images", "--format", "json"]
+    success, stdout, stderr = run_command(cmd)
+
+    if not success:
+        print(f"Error running list-images command: {stderr}")
+        return {}
+
+    try:
+        flat_list = json.loads(stdout)
+        # Convert to nested structure: distro -> arch -> [image_types]
+        nested_dict = {}
+        for item in flat_list:
+            distro_name = item["distro"]["name"]
+            arch_name = item["arch"]["name"]
+            image_type_name = item["image_type"]["name"]
+            nested_dict.setdefault(distro_name, {}).setdefault(arch_name, []).append(image_type_name)
+
+        return nested_dict
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON output from list-images: {e}")
+        return {}
+    except (KeyError, TypeError) as e:
+        print(f"Error processing list-images data structure: {e}")
+        return {}
+
+
+def describe_image(distro: str, arch: str, image_type: str) -> str:
+    """
+    Get image description using describe command.
+    """
+    cmd = [
+        "sudo", "podman", "run", "--rm", "--privileged", CONTAINER_IMAGE,
+        "describe", image_type, "--distro", distro, "--arch", arch
+    ]
+
+    success, stdout, stderr = run_command(cmd)
+    if not success:
+        print(f"Error running describe command for {distro}/{arch}/{image_type}: {stderr}")
+        return ""
+
+    lines = stdout.strip().splitlines()
+    if len(lines) < 1:
+        print(f"Unexpected output format for {distro}/{arch}/{image_type}")
+        return ""
+
+    # Remove the warning line if it exists (breaks YAML syntax)
+    yaml_lines = lines
+    if lines[0].startswith("@WARNING"):
+        yaml_lines = lines[1:]
+
+    if len(yaml_lines) < 1:
+        print(f"No YAML content found for {distro}/{arch}/{image_type}")
+        return ""
+
+    return '\n'.join(yaml_lines)
+
+
+def matches_filters(value: str, filters: List[str]) -> bool:
+    """
+    Check if a value matches any of the provided filters (regex or glob patterns).
+    """
+    if not filters:
+        return True
+
+    for filter_pattern in filters:
+        # Try as regex first
+        try:
+            if re.match(filter_pattern, value):
+                return True
+        except re.error:
+            pass
+
+        # Try as glob pattern
+        if fnmatch.fnmatch(value, filter_pattern):
+            return True
+
+    return False
+
+
+def filter_images(images_data: Dict, distro_filters: List[str], arch_filters: List[str], type_filters: List[str]) -> Dict:
+    """
+    Filter images based on provided filters.
+    """
+    filtered = {}
+
+    for distro, distro_data in images_data.items():
+        if not matches_filters(distro, distro_filters):
+            continue
+
+        filtered_distro = {}
+        for arch, arch_data in distro_data.items():
+            if not matches_filters(arch, arch_filters):
+                continue
+
+            filtered_arch = []
+            for image_type in arch_data:
+                if matches_filters(image_type, type_filters):
+                    filtered_arch.append(image_type)
+
+            if filtered_arch:
+                filtered_distro[arch] = filtered_arch
+
+        if filtered_distro:
+            filtered[distro] = filtered_distro
+
+    return filtered
+
+
+def create_anchor(text: str) -> str:
+    """
+    Create a URL-safe anchor from any text string.
+    Converts to lowercase, replaces spaces and underscores with hyphens,
+    removes dots, and handles other special characters.
+    """
+    return text.lower().replace(' ', '-').replace('_', '-').replace('.', '-').replace('(', '').replace(')', '').strip('-')
+
+
+def nice_distro_name(distro: str) -> Tuple[str, str]:
+    """
+    Convert a distro name to a nice name.
+    """
+    nice_names = {
+        "fedora": "Fedora",
+        "rhel": "Red Hat Enterprise Linux",
+        "centos": "CentOS Stream",
+        "centos-stream": "CentOS Stream",
+        "almalinux": "AlmaLinux OS",
+        "almalinux_kitten": "AlmaLinux OS Kitten",
+    }
+
+    distro_name, distro_version = distro.rsplit('-', 1)
+    return nice_names.get(distro_name, distro_name.title()), distro_version
+
+
+def images_list_to_distro_families(images_list: Dict) -> Dict:
+    """
+    Process the images data to group distributions by distro family.
+    Returns a dict of distro families, sorted by family name in reverse order to get RHEL at the top.
+    The versions within each family are sorted from the newest to the oldest.
+    The returned dict is useful for generating index pages and the correct directory structure.
+
+    The returned dict structure is
+    {
+        "nice_distro_name": [
+            ("distro_id", "version"),
+            ("distro_id", "version"),
+        ]
+    }
+    """
+    def version_key(item):
+        try:
+            version_parts = item[1].split('.', 1)
+            if len(version_parts) == 1:
+                return (int(version_parts[0]), 0)
+            else:
+                return (int(version_parts[0]), int(version_parts[1]))
+        except ValueError:
+            return (0, 0)
+
+    distro_families = {}
+    for distro in images_list.keys():
+        try:
+            nice_name, version = nice_distro_name(distro)
+            distro_families.setdefault(nice_name, []).append((distro, version))
+        except ValueError:
+            # Handle cases where distro name doesn't contain a version
+            distro_families[distro] = [(distro, "")]
+
+    distro_families = dict(sorted(distro_families.items(), reverse=True))
+
+    for family_name in distro_families.keys():
+        distro_families[family_name] = sorted(distro_families[family_name], key=version_key, reverse=True)
+
+    return distro_families
+
+
+def generate_page_footer(container_version: str, generation_date: str) -> str:
+    return f"""---
+*Generated using: `{container_version}`*
+
+*Last updated on: {generation_date}*"""
+
+
+def generate_image_type_page(
+    distro_name: str,
+    distro_version: str,
+    image_type: str,
+    arch_descriptions: Dict[str, str],
+    output_dir: pathlib.Path,
+    footer: str
+) -> pathlib.Path:
+    """
+    Generate a dedicated page for a specific image type.
+    Returns the filepath of the generated page.
+    """
+    content = f"""---
+custom_edit_url: https://github.com/osbuild/osbuild.github.io/blob/main/scripts/pull_image_descriptions.py
+---
+
+# {image_type}
+
+<!--
+[//]: # ( DO NOT MODIFY THIS FILE! )
+[//]: # ( This content is generated by `scripts/pull_image_descriptions.py` )
+[//]: # ( Generated on: {GENERATION_DATE} )
+-->
+
+Image description for **{image_type}** on **{distro_name} {distro_version}**.
+
+The descriptions below describe the base image version, that can be further customized by the user using the [Blueprint customizations](../../01-blueprint-reference.md).
+
+:::note[Package sets]
+
+Each image description contains a list of base packages that make up the image. This list is dependency-resolved using the distribution's package manager and subsequently installed into the image. This means that the list of actually installed packages depends on the available RPM repositories and the dependencies of the packages listed in the image's base package set.
+
+:::
+
+:::warning[Do not rely on the image description format]
+
+The format of the image description is not guaranteed to be stable. It is published for informational purposes only.
+
+:::
+
+"""
+    # Add table of contents for architectures if multiple architectures exist
+    if len(arch_descriptions) > 1:
+        content += "## Architectures\n\n"
+        for arch in sorted(arch_descriptions.keys()):
+            content += f"- [{arch}](#{create_anchor(arch)})\n"
+        content += "\n"
+
+    # Add individual architecture descriptions
+    for arch, description in sorted(arch_descriptions.items()):
+        content += f"## {arch} {{#{create_anchor(arch)}}}\n\n"
+        content += f"```yaml\n{description}\n```\n\n"
+
+    # Add footer
+    content += f"\n{footer}\n"
+
+    filepath = output_dir / f"{image_type}.md"
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+    return filepath
+
+
+def generate_distro_index_page(
+    distro_name: str,
+    distro_version: str,
+    image_type_page_info: Dict,
+    output_dir: pathlib.Path,
+    footer: str
+) -> pathlib.Path:
+    """
+    Generate a dedicated page for a specific distribution.
+    Returns the filepath of the generated page.
+    """
+    content = f"""---
+custom_edit_url: https://github.com/osbuild/osbuild.github.io/blob/main/scripts/pull_image_descriptions.py
+---
+
+# {distro_name} {distro_version}
+
+<!--
+[//]: # ( DO NOT MODIFY THIS FILE! )
+[//]: # ( This content is generated by `scripts/pull_image_descriptions.py` )
+[//]: # ( Generated on: {GENERATION_DATE} )
+-->
+
+This page describes the image types and architectures available for **{distro_name} {distro_version}**.
+
+## Image Types
+
+"""
+    for image_type, (image_page_relative, arch_anchors) in image_type_page_info.items():
+        arch_links = [f"[{arch}](./{image_page_relative}#{arch_anchor})" for arch, arch_anchor in arch_anchors.items()]
+        content += f"- [{image_type}](./{image_page_relative}) ({', '.join(arch_links)})\n"
+    content += "\n"
+
+    # Add footer
+    content += f"\n{footer}\n"
+
+    filepath = output_dir / "index.md"
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+    return filepath
+
+
+def generate_main_index_page(
+    distro_pages_info: Dict,
+    output_dir: pathlib.Path,
+    footer: str
+) -> pathlib.Path:
+    """
+    Generate the main index page.
+    Returns the filepath of the generated page.
+    """
+    content = f"""---
+custom_edit_url: https://github.com/osbuild/osbuild.github.io/blob/main/scripts/pull_image_descriptions.py
+---
+
+# Image Descriptions
+
+<!--
+[//]: # ( DO NOT MODIFY THIS FILE! )
+[//]: # ( This content is generated by `scripts/pull_image_descriptions.py` )
+[//]: # ( Generated on: {GENERATION_DATE} )
+-->
+
+This section describes the distributions available in the latest upstream version of the Image Builder tooling.
+
+:::note
+
+The list of available distributions may vary depending on the method used to build an image (e.g., `image-builder` CLI, `osbuild-composer`, Red Hat Insights service, etc.). It also depends on the host distribution and its version when building images locally.
+
+:::
+
+"""
+    # Add table of contents
+    content += "## Available Distributions\n\n"
+    for family_name, family_distros in distro_pages_info.items():
+
+        content += f"### {family_name}\n\n"
+        for distro_version, distro_page_relative in family_distros:
+            content += f"- [{family_name} **{distro_version}**](./{distro_page_relative})\n"
+        content += "\n"
+
+    # Add footer
+    content += f"\n{footer}\n"
+
+    index_path = output_dir / "index.md"
+    with open(index_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+    return index_path
+
+
+def main():
+    """Main function."""
+    parser = argparse.ArgumentParser(
+        description="Pull image descriptions and generate markdown documentation"
+    )
+    parser.add_argument(
+        "--distro-filter",
+        action="append",
+        help="Filter distributions (regex or glob pattern, can specify multiple)"
+    )
+    parser.add_argument(
+        "--arch-filter",
+        action="append",
+        help="Filter architectures (regex or glob pattern, can specify multiple)"
+    )
+    parser.add_argument(
+        "--type-filter",
+        action="append",
+        help="Filter image types (regex or glob pattern, can specify multiple)"
+    )
+
+    args = parser.parse_args()
+
+    if not pull_container_image():
+        print("Failed to pull container image")
+        return 1
+
+    print("Getting container version...")
+    container_version = get_container_version()
+    print(f"Container version: {container_version}")
+
+    print("Fetching list of supported images...")
+    images_data = list_images()
+    if not images_data:
+        print("Failed to get list of images")
+        return 1
+
+    print("Applying filters...")
+    filtered_images = filter_images(
+        images_data,
+        args.distro_filter or [],
+        args.arch_filter or [],
+        args.type_filter or []
+    )
+
+    if not filtered_images:
+        print("No images match the specified filters")
+        return 1
+
+    image_types_count = sum(
+        [sum([len(image_types) for image_types in arches.values()]) for arches in filtered_images.values()]
+    )
+    print(f"Processing {image_types_count} image type combinations...")
+
+    distro_families = images_list_to_distro_families(filtered_images)
+    page_footer = generate_page_footer(container_version, GENERATION_DATE)
+
+    # Create temporary directory for generation
+    image_types_processed = 0
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+
+        # Dictionary to store distro page info: distro_name -> [("version", "filepath"), ("version", "filepath"), ...]
+        distro_pages_info = {}
+
+        # Generate individual image type pages
+        distro_id_idx = 0
+        for distro_name, family_distros in distro_families.items():
+            for distro_id, version in family_distros:
+                distro_id_dir = temp_path / f"{distro_id_idx:02d}-{distro_id}"
+                distro_id_idx += 1
+                distro_id_dir.mkdir(parents=True, exist_ok=True)
+                distro_data = filtered_images[distro_id]
+
+                # Group descriptions by image type across architectures
+                image_types = set()
+                for arch_data in distro_data.values():
+                    image_types.update(arch_data)
+
+                # Dictionary to store image page info: image_type -> (filepath, arch_anchors)
+                image_type_pages_info = {}
+
+                for image_type in image_types:
+                    print(f"[{image_types_processed}/{image_types_count}] Processing {distro_id}/{image_type}...")
+
+                    # Get image type descriptions for all architectures that it supports
+                    arch_descriptions = {}
+                    for arch, types in distro_data.items():
+                        if image_type in types:
+                            description = describe_image(distro_id, arch, image_type)
+                            image_types_processed += 1
+                            if not description:
+                                print(f"WARNING: Failed to describe {distro_id}/{arch}/{image_type}")
+                                continue
+                            arch_descriptions[arch] = description
+
+                    if arch_descriptions:
+                        image_page = generate_image_type_page(
+                            distro_name, version, image_type, arch_descriptions, distro_id_dir, page_footer
+                        )
+                        image_page_relative = image_page.relative_to(distro_id_dir)
+                        print(f"Generated: {image_page_relative}")
+
+                        arch_anchors = {arch: create_anchor(arch) for arch in arch_descriptions.keys()}
+                        image_type_pages_info[image_type] = (image_page_relative, arch_anchors)
+
+                print(f"Generating {distro_name} {version} index page...")
+                distro_page = generate_distro_index_page(
+                    distro_name, version, image_type_pages_info, distro_id_dir, page_footer
+                )
+                distro_page_relative = distro_page.relative_to(temp_dir)
+                print(f"Generated: {distro_page_relative}")
+
+                distro_pages_info.setdefault(distro_name, []).append((version, distro_page_relative))
+
+        print("Generating main index page...")
+        generate_main_index_page(distro_pages_info, temp_path, page_footer)
+
+        print(f"Replacing content in {TARGET_DIR}...")
+        if TARGET_DIR.exists():
+            shutil.rmtree(TARGET_DIR)
+        shutil.move(str(temp_path), str(TARGET_DIR))
+
+        print("Successfully generated image descriptions documentation!")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Update npm packages to fix vulnerabilities**

---

**Add script to pull image descriptions**

Add a script that pulls the latest version of the image-builder CLI
container and uses it to generate upstream documentation describing the
available distributions, architectures and image types. The generated
set can be filtered.

The script groups available distributions by the distribution name (or
family as being referred to by the script code).

The AI agent has been used to:
 - Generate helper functions to pull and call image-builder container.
 - Generate the script CLI interface.
 - Generate the filtering functionality for the CLI arguments.

Assisted-by: Cursor (claude-4-sonnet)

---

**GHA: pull image descriptions when generating docs**

---