### PR TITLE
Fix pulling of READMEs

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,4 +1,6 @@
-name: Update developer guide
+name: Pull project-specific documentation
+# This workflow pulls the latest project-specific documentation from various repositories
+# and updates the upstream documentation in the osbuild.github.io repository.
 
 on:
   workflow_dispatch:

--- a/scripts/test_pull_readmes.py
+++ b/scripts/test_pull_readmes.py
@@ -12,6 +12,16 @@ class TestResolveDirs(unittest.TestCase):
         absolute_link = resolve_dirs(self.baseurl, relative_link)
         self.assertEqual( "https://github.com/osbuild/tree/main/docs/file.md", absolute_link)
 
+    def test_resolve_dirs_starting_with_slash_md(self):
+        relative_link = "/test/README.md"
+        absolute_link = resolve_dirs(self.baseurl, relative_link)
+        self.assertEqual("../test/README.md", absolute_link)
+
+    def test_resolve_dirs_starting_with_slash(self):
+        relative_link = "/test/file.txt"
+        absolute_link = resolve_dirs(self.baseurl, relative_link)
+        self.assertEqual("https://github.com/osbuild/tree/main/test/file.txt", absolute_link)
+
     def test_resolve_dirs_starting_with_dot_slash(self):
         relative_link = "./path/to/file.md"
         absolute_link = resolve_dirs(self.baseurl, relative_link)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -18,40 +18,40 @@ POST_TITLE_TEMPLATE = """
 RELATIVE_LINK_PATTERN = r'\[(.*?)\]\((.*?)\)'
 
 
-def resolve_dirs(baseurl, relative_link):
+def resolve_dirs(baseurl, link):
     """
-    Resolve relative links to absolute links.
+    Resolve relative or absolute links.
     """
     baseurl = baseurl.replace("/main/", "/tree/main/")
 
-    if relative_link.startswith("./"):
-        relative_link = relative_link[2:]
-    elif relative_link.startswith("../"):
-        relative_link = relative_link[3:]
+    if link.startswith("./"):
+        link = link[2:]
+    elif link.startswith("../"):
+        link = link[3:]
         baseurl = "/".join(baseurl.split("/")[0:-1])
-    elif relative_link.startswith("/"):
+    elif link.startswith("/"):
         # Links starting with "/" are relative to the repository root
-        relative_link = relative_link[1:]
+        link = link[1:]
 
         # For .md files, convert to relative path
-        if relative_link.endswith('.md'):
+        if link.endswith('.md'):
             # Extract the file path from baseurl
             match = re.search(r'.*/tree/main/(.+)', baseurl)
             if match:
                 current_file_path = match.group(1)
                 current_dir = os.path.dirname(current_file_path)
-                relative_path = os.path.relpath(relative_link, current_dir)
+                relative_path = os.path.relpath(link, current_dir)
                 return relative_path
 
         # For non-.md files, convert to absolute URL
-        return re.sub(r'/tree/main/.*$', f'/tree/main/{relative_link}', baseurl)
+        return re.sub(r'/tree/main/.*$', f'/tree/main/{link}', baseurl)
 
-    if relative_link.startswith("#"):
+    if link.startswith("#"):
         # Don't modify anchors
-        return relative_link
+        return link
 
     baseurl = re.sub(r'/[^/]+$', '', baseurl) + "/"
-    absolute_link = f'{baseurl}{relative_link}'
+    absolute_link = f'{baseurl}{link}'
     return absolute_link
 
 def replace_relative_links(match, baseurl):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,5 +1,6 @@
 
 import re
+import os
 
 PRE_TITLE_TEMPLATE = """---
 custom_edit_url: {custom_edit_url}
@@ -28,6 +29,22 @@ def resolve_dirs(baseurl, relative_link):
     elif relative_link.startswith("../"):
         relative_link = relative_link[3:]
         baseurl = "/".join(baseurl.split("/")[0:-1])
+    elif relative_link.startswith("/"):
+        # Links starting with "/" are relative to the repository root
+        relative_link = relative_link[1:]
+
+        # For .md files, convert to relative path
+        if relative_link.endswith('.md'):
+            # Extract the file path from baseurl
+            match = re.search(r'.*/tree/main/(.+)', baseurl)
+            if match:
+                current_file_path = match.group(1)
+                current_dir = os.path.dirname(current_file_path)
+                relative_path = os.path.relpath(relative_link, current_dir)
+                return relative_path
+
+        # For non-.md files, convert to absolute URL
+        return re.sub(r'/tree/main/.*$', f'/tree/main/{relative_link}', baseurl)
 
     if relative_link.startswith("#"):
         # Don't modify anchors


### PR DESCRIPTION
**GHA: rename the 'pull.yml' workflow**

---

**scripts/util.py: enhance resolve_dirs() to handle absolute links**

It turned out that absolute links (starting with '/') were not resolved
correctly, which lead to broken links and READMEs not being updated for
more than 2 months.

Extend the resolve_dirs() function to handle this case correctly. The
behavior is that such links to '.md' files are replaces with relative
links within the pulled documentation, while links to any other file
types are converted to full URLs.

Extend the unit tests to cover these scenarios.

---

**scripts/utils.py: rename resolve_dirs() argument**

This better reflects what types of links are passed as arguments. Also
adjust the doc text.

---