### PR TITLE
scripts/utils.py: call resolve_dirs() on .md links starting with /

### DIFF
--- a/scripts/test_pull_readmes.py
+++ b/scripts/test_pull_readmes.py
@@ -46,7 +46,7 @@ class TestResolveDirs(unittest.TestCase):
 
         test_cases = [
             {
-                'description': "Test Markdown relative link replacement",
+                'description': "Test Markdown relative link remains unchanged",
                 'content': "[my link](../path/to/file.md)",
                 'expected': "[my link](../path/to/file.md)"
             },
@@ -59,6 +59,16 @@ class TestResolveDirs(unittest.TestCase):
                 'description': "Test folder relative link replacement",
                 'content': "[my link](./some/path/to/)",
                 'expected': "[my link](https://github.com/osbuild/tree/main/docs/some/path/to/)"
+            },
+            {
+                'description': "Test repository root relative .md link gets converted to relative path",
+                'content': "[test README](/test/README.md)",
+                'expected': "[test README](../test/README.md)"
+            },
+            {
+                'description': "Test repository root relative non-.md link gets converted to absolute URL",
+                'content': "[test file](/test/file.txt)",
+                'expected': "[test file](https://github.com/osbuild/tree/main/test/file.txt)"
             }
         ]
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -61,7 +61,12 @@ def replace_relative_links(match, baseurl):
     link_text = match.group(1)
     relative_link = match.group(2)
 
-    if relative_link.endswith('.md') or relative_link.startswith('http'):
+    # Don't modify HTTP links
+    if relative_link.startswith('http'):
+        return match.group(0)
+
+    # Don't modify .md links unless they start with / (repository root relative)
+    if relative_link.endswith('.md') and not relative_link.startswith('/'):
         return match.group(0)
 
     absolute_link = resolve_dirs(baseurl, relative_link)


### PR DESCRIPTION
Although the `resolve_dirs()` have been modified to handle absolute links for .md files, I forgot to make sure that we call it on such links in the replace_relative_links() function in the first place. This is now fixed by adjusting the condition in the function.

In addition, extend the unit tests to explicitly test for this scenario.