### PR TITLE
dev-guide: single-line commits

### DIFF
--- a/docs/developer-guide/01-general/workflow.md
+++ b/docs/developer-guide/01-general/workflow.md
@@ -5,11 +5,12 @@
 1. Commits should be easy to read and ideally do only a single thing.
 2. The commit message should explain clearly what it's trying to do and why. Refer to the format we prefer below.
 3. A Jira issue or - where applicable - a GitHub issue reference should be added to automatically link and potentially close a related issue if it exists.
+4. Avoid single-line commits.
 
 ### Preferred commit message format
 
 ```
-<module>: Topic of the commit
+<module>: topic of the commit
 
 Body of the commit, describing the changes in more detail including the
 why/what/how.


### PR DESCRIPTION
The guide does not actually elaborate on the fact that multi-line commits are preferred. Many teams do prefer single-line commits and keep all the conversation on sites like github.com so it was not obvious for me.

This change also aligns the capital letter of the first line with what is the majority of current commits across projects.

---

Comment for the capital letter - it looks like most of us prefer `module - small character` including myself because the first line should not form a sentence it needs to be super short. I can drop this from the patch if you feel this does not need an update, tho I like recommending what majority actually do.

Edit: Shall I add something about text wrapping? I just created a multi-line commit in VSCode for the first time (I usually use Vim) and it does not wrap the text at all.