### PR TITLE
blueprint: mention openscap removing packages

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -135,6 +135,8 @@ version = "*"
 
 The content section determines what goes into the image from other sources such as packages, package groups, or containers. Content is defined at the root of the blueprint.
 
+Note that content can also be adjusted by other customizations. For example, a selected OpenSCAP profile might remove packages even when explicitly selected to be installed under the content section.
+
 ### Packages 🔵&nbsp;🟤 {#packages}
 
 The `packages` and `modules` lists contain objects with a `name` and optional `version` attribute.


### PR DESCRIPTION
A user reported in our Matrix channel that applying certain OpenSCAP profiles will remove packages and their dependencies. This is (sometimes) incompatible with previously selected packages.

For example, installing the environment
`workstation-product-environment` and applying the `xccdf_org.ssgproject.content_profile_stig_gui` OpenSCAP profile will remove `tuned` and all its dependents (which is half of GNOME).

Let's note this so people know where to look.