### PR TITLE
Update docs to reference image builder CLI

### DIFF
--- a/docs/on-premises/00-overview/01-basic-concepts.md
+++ b/docs/on-premises/00-overview/01-basic-concepts.md
@@ -1,13 +1,13 @@
 # Basic concepts
 
-`osbuild-composer` works with a concept of **blueprints**. A blueprint is a description of the final **image** and its **customizations**. A **customization** can be:
+A blueprint is a description of the final **image** and its **customizations**. A **customization** can be:
 * an additional RPM package
 * enabled service
 * custom kernel command line parameter, and many others. See [Blueprint](../../user-guide/01-blueprint-reference.md) reference for more details.
 
 An **image** is defined by its blueprint and **image type**, which is for example `qcow2` (QEMU Copy On Write disk image) or `AMI` (Amazon Machine Image).
 
-Finally, `osbuild-composer` also supports **upload targets**, which are cloud providers where an image can be stored after it is built. See the [Uploading cloud images](../../user-guide/04-uploading-cloud-images/index.md) section for more details.
+Image builder also supports **upload targets**, which are cloud providers where an image can be stored after it is built. See the [Uploading cloud images](../../user-guide/04-uploading-cloud-images/index.md) section for more details.
 
 ## Example blueprint
 
@@ -25,7 +25,15 @@ The blueprint is in [TOML format](https://toml.io/en/).
 
 ## Image types
 
-`osbuild-composer` supports various types of output images. To see all supported types, run this command:
+Image builder supports various types of output images. To see all supported types, run this command:
+
+Using the `image-builder` CLI: 
+
+```
+$ image-builder list
+```
+
+Using the `composer-cli` CLI: 
 
 ```
 $ composer-cli compose types

--- a/docs/on-premises/00-overview/index.md
+++ b/docs/on-premises/00-overview/index.md
@@ -11,13 +11,19 @@ You can see an overview of [which version is released where here](./02-release-o
 
 `osbuild-composer` is a service for building customized operating system images (currently only Fedora and RHEL). These images can be used with various virtualization software such as [QEMU](https://www.qemu.org/), [VirtualBox](https://www.virtualbox.org/), [VMWare](https://www.vmware.com/) and also with cloud computing providers like [AWS](https://aws.amazon.com/), [Azure](https://azure.microsoft.com/) or [GCP](https://cloud.google.com/).
 
-There are two frontends that you can use to communicate with osbuild-composer:
+There are two interfaces that you can use to communicate with osbuild-composer:
 
 - **Cockpit Composer**: The web-based management console [Cockpit](https://cockpit-project.org/) comes bundled with a UI extension to build operating system artifacts. See the documentation of Cockpit Composer for information, or consult the Cockpit Guide for help on general Cockpit questions.
 
 - **Command-line Interface**: With composer-cli there exists a linux command-line interface (CLI) to some of the functionality provided by OSBuild. The CLI is part of the Weldr project, a precursor of OSBuild.
 
-This guide contains instructions on installing `osbuild-composer` service and its basic usage.
+## New image-builder CLI 
+
+This guide contains instructions on installing `osbuild-composer` service and its basic usage. This guide also contains instructions for using the new `image-builder` CLI. 
+
+The image-builder CLI moves away from the legacy service-based model in favor of a stateless, tool-based architecture. This removes the need for background daemons or database management: the tool runs client-side and blueprints are passed directly as local `.toml` files rather than uploaded. For more information about the `image-builder` CLI, see the [osbuild/image-builder repo on GitHub](https://github.com/osbuild/image-builder-cli).  
+
+## Contribute 
 
 If you want to fix a typo, or even contribute new content, the sources for this webpage are hosted in [osbuild/osbuild.github.io GitHub repository](https://github.com/osbuild/osbuild.github.io).
 

--- a/docs/on-premises/01-installation/index.md
+++ b/docs/on-premises/01-installation/index.md
@@ -1,6 +1,6 @@
 # Installation and configuration
 
-To get started with `image-builder` CLI on your local machine, you can install the CLI interface or the Web UI, which is part of Cockpit project. 
+To get started with `image-builder` CLI on your local machine, install the CLI interface. 
 
 ## Using the image-builder CLI interface
 
@@ -29,7 +29,7 @@ $ sudo image-builder build qcow2 --distro centos-9
 To customize the image, create a blueprint:
 
 ```
-$ sudo vim centos-9-custom.toml
+$ vim centos-9-custom.toml
 ```
 
 In the `centos-9-custom.toml` file, specify the customizations you want to add. The following example specifies a username, password, and group to preconfigure:
@@ -37,9 +37,11 @@ In the `centos-9-custom.toml` file, specify the customizations you want to add. 
 ```
 [[customizations.user]]
 name = "admin"
-password = "$6cnwJk44gH" 
+password = "_secure-hashed-password_" 
 groups = ["wheel"]
 ```
+Note that you cannot enter a plain-text password. You must provide a secure, hashed version.  
+
 
 Use the blueprint to build the image: 
 
@@ -76,7 +78,7 @@ If you prefer to run this command without sudo privileges, add your user to the 
 
 ```
 $ sudo usermod -a -G weldr <user>
-$ newgrp weldr
+$ sudo newgrp weldr
 ```
 
 ## Web UI
@@ -108,36 +110,3 @@ and enable `cockpit` and `osbuild-composer` services:
 $ sudo systemctl enable --now osbuild-composer.socket
 $ sudo systemctl enable --now cockpit.socket
 ```
-
-
-
-## Web UI
-
-If you prefer the Web UI interface, known as Cockpit image builder, install the following package:
-
-```
-$ sudo dnf install cockpit-image-builder
-```
-
-and enable `cockpit` and `osbuild-composer` services:
-
-```
-$ sudo systemctl enable --now osbuild-composer.socket
-$ sudo systemctl enable --now cockpit.socket
-```
-
-### Web UI before RHEL 10, CentOS 10 and fedora 42
-
-Cockpit composer is the old web UI, still available on RHEL 9 and CentOS 9:
-
-```
-$ sudo dnf install cockpit-composer
-```
-
-and enable `cockpit` and `osbuild-composer` services:
-
-```
-$ sudo systemctl enable --now osbuild-composer.socket
-$ sudo systemctl enable --now cockpit.socket
-```
-

--- a/docs/on-premises/01-installation/index.md
+++ b/docs/on-premises/01-installation/index.md
@@ -2,19 +2,12 @@
 
 To get started with `image-builder` CLI on your local machine, you can install the CLI interface or the Web UI, which is part of Cockpit project. 
 
-## CLI interface
+## Using the image-builder CLI interface
 
 For CLI only, enter the following command to install required packages:
 
 ```
 $ sudo dnf install image-builder osbuild osbuild-depsolve-dnf
-```
-
-To use image-builder CLI without sudo privileges, add your user to the `weldr` group:
-
-```
-$ sudo usermod -a -G weldr <user>
-$ newgrp weldr
 ```
 
 To list all available options, enter the following command:
@@ -53,6 +46,69 @@ Use the blueprint to build the image:
 ```
 $ sudo image-builder build qcow2 --distro centos-9 --blueprint ./centos-9-custom.toml
 ```
+## Using the `composer-cli`
+
+To get started with `osbuild-composer` on your local machine, you can install the CLI interface or the Web UI, which is part of Cockpit project. 
+
+## CLI interface
+
+For CLI only, run the following command to install necessary packages:
+
+```
+$ sudo dnf install osbuild-composer composer-cli
+```
+
+Note that `composer-cli` is a virtual provides for the actual package name, which is `weldr-client` for historical reasons.
+
+To enable the service, run this command:
+
+```
+$ sudo systemctl enable --now osbuild-composer.socket
+```
+
+Verify that the installation works by running `composer-cli`:
+
+```
+$ sudo composer-cli status show
+```
+
+If you prefer to run this command without sudo privileges, add your user to the `weldr` group:
+
+```
+$ sudo usermod -a -G weldr <user>
+$ newgrp weldr
+```
+
+## Web UI
+
+If you prefer the Web UI interface, known as Cockpit image builder, install the following package:
+
+```
+$ sudo dnf install cockpit-image-builder
+```
+
+and enable `cockpit` and `osbuild-composer` services:
+
+```
+$ sudo systemctl enable --now osbuild-composer.socket
+$ sudo systemctl enable --now cockpit.socket
+```
+
+### Web UI before RHEL 10, CentOS 10 and fedora 42
+
+Cockpit composer is the old web UI, still available on RHEL 9 and CentOS 9:
+
+```
+$ sudo dnf install cockpit-composer
+```
+
+and enable `cockpit` and `osbuild-composer` services:
+
+```
+$ sudo systemctl enable --now osbuild-composer.socket
+$ sudo systemctl enable --now cockpit.socket
+```
+
 
 
 ## Web UI

--- a/docs/on-premises/01-installation/index.md
+++ b/docs/on-premises/01-installation/index.md
@@ -78,7 +78,7 @@ If you prefer to run this command without sudo privileges, add your user to the 
 
 ```
 $ sudo usermod -a -G weldr <user>
-$ sudo newgrp weldr
+$ newgrp weldr
 ```
 
 ## Web UI

--- a/docs/on-premises/01-installation/index.md
+++ b/docs/on-premises/01-installation/index.md
@@ -1,35 +1,59 @@
 # Installation and configuration
 
-To get started with `osbuild-composer` on your local machine, you can install the CLI interface or the Web UI, which is part of Cockpit project. 
+To get started with `image-builder` CLI on your local machine, you can install the CLI interface or the Web UI, which is part of Cockpit project. 
 
 ## CLI interface
 
-For CLI only, run the following command to install necessary packages:
+For CLI only, enter the following command to install required packages:
 
 ```
-$ sudo dnf install osbuild-composer composer-cli
+$ sudo dnf install image-builder osbuild osbuild-depsolve-dnf
 ```
 
-Note that `composer-cli` is a virtual provides for the actual package name, which is `weldr-client` for historical reasons.
-
-To enable the service, run this command:
-
-```
-$ sudo systemctl enable --now osbuild-composer.socket
-```
-
-Verify that the installation works by running `composer-cli`:
-
-```
-$ sudo composer-cli status show
-```
-
-If you prefer to run this command without sudo privileges, add your user to the `weldr` group:
+To use image-builder CLI without sudo privileges, add your user to the `weldr` group:
 
 ```
 $ sudo usermod -a -G weldr <user>
 $ newgrp weldr
 ```
+
+To list all available options, enter the following command:
+
+```
+$ image-builder list
+```
+
+### Standard build
+
+To build a basic QCOW2 image for CentOS Stream 9:
+
+```
+$ sudo image-builder build qcow2 --distro centos-9
+```
+
+### Custom build
+
+To customize the image, create a blueprint:
+
+```
+$ sudo vim centos-9-custom.toml
+```
+
+In the `centos-9-custom.toml` file, specify the customizations you want to add. The following example specifies a username, password, and group to preconfigure:
+
+```
+[[customizations.user]]
+name = "admin"
+password = "$6cnwJk44gH" 
+groups = ["wheel"]
+```
+
+Use the blueprint to build the image: 
+
+```
+$ sudo image-builder build qcow2 --distro centos-9 --blueprint ./centos-9-custom.toml
+```
+
 
 ## Web UI
 

--- a/docs/on-premises/01-installation/managing-repositories.md
+++ b/docs/on-premises/01-installation/managing-repositories.md
@@ -7,6 +7,34 @@ There are two kinds of repositories used in osbuild-composer:
 
 ## Custom 3rd party repositories
 
+### Using the `image-builder` CLI
+
+With the `image-builder` CLI, you simply pass the repository URL using the --extra-repo flag when running the build command. You can use this flag multiple times.
+
+```
+$ image-builder build qcow2 \
+  --distro centos-9 \
+  --extra-repo https://my.custom.repo/path \
+  --extra-repo https://another.repo/path
+
+```
+
+If you need to replace the official repositories (for example, to use a local mirror for everything), you use the `--force-data-dir` flag.
+
+1. Create a local directory (e.g., ./my-repos).
+
+2. Create a `.json` file inside it matching the distro name (e.g., centos-9.json). For examples of how to format the JSON, see [defining overrides](#defining-official-repository-overrides). 
+
+3. Run the build pointing to that directory:
+
+```
+image-builder build qcow2 \
+  --distro centos-9 \
+  --force-data-dir ./my-repos
+```
+
+### Using the `composer-cli`
+
 These are managed using `composer-cli` (see the manpage for complete reference). To add a new repository, create a `TOML` file like this:
 
 ```toml
@@ -32,20 +60,20 @@ Sources with no `distros` will be used with all composes. If you want to use a
 source for a specific distro you set the `distros` list to the distro name(s)
 to use it with.
 
-eg. A source that is only used when depsolving or building fedora 32:
+eg. A source that is only used when depsolving or building fedora 42:
 
 ```toml
 check_gpg = true
 check_ssl = true
-distros = ["fedora-32"]
-id = "f32-local"
-name = "local packages for fedora32"
+distros = ["fedora-42"]
+id = "f42-local"
+name = "local packages for fedora42"
 type = "yum-baseurl"
-url = "http://local/repos/fedora32/projectrepo/"
+url = "http://local/repos/fedora42/projectrepo/"
 ```
 
-This source will be used for any requests that specify fedora-32, eg. listing
-packages and specifying fedora-32 will include this source, but listing
+This source will be used for any requests that specify fedora-42, eg. listing
+packages and specifying fedora-42 will include this source, but listing
 packages for the host distro will not.
 
 ### Verifying Repository Metadata with GPG

--- a/docs/on-premises/01-installation/managing-repositories.md
+++ b/docs/on-premises/01-installation/managing-repositories.md
@@ -12,7 +12,7 @@ There are two kinds of repositories used in osbuild-composer:
 With the `image-builder` CLI, you simply pass the repository URL using the --extra-repo flag when running the build command. You can use this flag multiple times.
 
 ```
-$ sudo mage-builder build qcow2 \
+$ sudo image-builder build qcow2 \
   --distro centos-9 \
   --extra-repo https://my.custom.repo/path \
   --extra-repo https://another.repo/path

--- a/docs/on-premises/01-installation/managing-repositories.md
+++ b/docs/on-premises/01-installation/managing-repositories.md
@@ -12,14 +12,14 @@ There are two kinds of repositories used in osbuild-composer:
 With the `image-builder` CLI, you simply pass the repository URL using the --extra-repo flag when running the build command. You can use this flag multiple times.
 
 ```
-$ image-builder build qcow2 \
+$ sudo mage-builder build qcow2 \
   --distro centos-9 \
   --extra-repo https://my.custom.repo/path \
   --extra-repo https://another.repo/path
 
 ```
 
-If you need to replace the official repositories (for example, to use a local mirror for everything), you use the `--force-data-dir` flag.
+If you need to replace the official repositories (for example, to use a local mirror for everything), use the `--force-data-dir` flag.
 
 1. Create a local directory (e.g., ./my-repos).
 
@@ -28,7 +28,7 @@ If you need to replace the official repositories (for example, to use a local mi
 3. Run the build pointing to that directory:
 
 ```
-image-builder build qcow2 \
+$ sudo image-builder build qcow2 \
   --distro centos-9 \
   --force-data-dir ./my-repos
 ```

--- a/docs/on-premises/02-commandline/building-ostree-images.md
+++ b/docs/on-premises/02-commandline/building-ostree-images.md
@@ -52,7 +52,7 @@ version = "*"
 ### Using the image-builder CLI: 
 
 ```
-$ image-builder build iot-commit   --distro fedora-43   --blueprint fishy.toml 
+$ sudo image-builder build iot-commit   --distro fedora-43   --blueprint fishy.toml 
 ```
 
 This command produces a `.tar` file. 
@@ -62,26 +62,26 @@ This command produces a `.tar` file.
 Push the blueprint to osbuild-composer using `composer-cli`:
 
 ```
-$ composer-cli blueprints push fishy.toml
+$ sudo composer-cli blueprints push fishy.toml
 ```
 
 And start a build:
 
 ```
-$ composer-cli compose start fishy-commit fedora-iot-commit
+$ sudo composer-cli compose start fishy-commit fedora-iot-commit
 Compose 8e8014f8-4d15-441a-a26d-9ed7fc89e23a added to the queue
 ```
 
 Monitor the build status using:
 
 ```
-$ composer-cli compose status
+$ sudo composer-cli compose status
 ```
 
 And finally when the compose is complete, download the result:
 
 ```
-$ composer-cli compose image 8e8014f8-4d15-441a-a26d-9ed7fc89e23a
+$ sudo composer-cli compose image 8e8014f8-4d15-441a-a26d-9ed7fc89e23a
 8e8014f8-4d15-441a-a26d-9ed7fc89e23a-commit.tar: 670.45 MB
 ```
 

--- a/docs/on-premises/02-commandline/building-ostree-images.md
+++ b/docs/on-premises/02-commandline/building-ostree-images.md
@@ -1,6 +1,6 @@
 # Building OSTree image
 
-This section contains a guide for building OSTree commits. As opposed to the "traditional" image types, these commits are not directly bootable so although they basically contain a full operating system, in order to boot them, they need to be deployed. This can, for example, be done via the  Fedora installer (Anaconda).
+This section contains a guide for building OSTree commits. As opposed to the "traditional" image types, these commits are not directly bootable so although they basically contain a full operating system, in order to boot them, they need to be deployed. This can, for example, be done via the Fedora installer (Anaconda).
 
 OSTree is a technology for creating immutable operating system images and it is a base for Fedora CoreOS, Fedora IoT, Fedora Silverblue, and RHEL for Edge. For more information on OSTree, see [their website](https://ostreedev.github.io/ostree/).
 
@@ -49,7 +49,17 @@ name = "fish"
 version = "*"
 ```
 
-Now push the blueprint to osbuild-composer using `composer-cli`:
+### Using the image-builder CLI: 
+
+```
+$ image-builder build iot-commit   --distro fedora-43   --blueprint fishy.toml 
+```
+
+This command produces a `.tar` file. 
+
+## Using `composer-cli`:
+
+Push the blueprint to osbuild-composer using `composer-cli`:
 
 ```
 $ composer-cli blueprints push fishy.toml

--- a/docs/on-premises/02-commandline/building-ostree-images.md
+++ b/docs/on-premises/02-commandline/building-ostree-images.md
@@ -52,7 +52,7 @@ version = "*"
 ### Using the image-builder CLI: 
 
 ```
-$ sudo image-builder build iot-commit   --distro fedora-43   --blueprint fishy.toml 
+$ sudo image-builder build iot-commit --distro fedora-43 --blueprint fishy.toml 
 ```
 
 This command produces a `.tar` file. 

--- a/docs/on-premises/02-commandline/edge-container+installer.md
+++ b/docs/on-premises/02-commandline/edge-container+installer.md
@@ -17,7 +17,7 @@ Note that there are some small differences in this procedure between RHEL 8.4 an
 
 The `edge-container` image type creates an OSTree commit and embeds it into an OCI container with a web server. When the container is started, the web server serves the commit as an OSTree repository.
 
-The `edge-intaller` image type pulls the commit from the running container and creates an installable boot ISO with a kickstart file configured to use the embedded OSTree commit.
+The `edge-installer` image type pulls the commit from the running container and creates an installable boot ISO with a kickstart file configured to use the embedded OSTree commit.
 
 ## Detailed workflow
 

--- a/docs/on-premises/02-commandline/index.md
+++ b/docs/on-premises/02-commandline/index.md
@@ -1,5 +1,7 @@
 # Using the commandline
 
+## Using the image-builder CLI
+
 An image is specified by a blueprint and an image type. Unless you specify otherwise, it will use the same distribution and version (e.g. Fedora 43) as the host system. The architecture will always be the same as the one on the host.
 
 ## Create a blueprint
@@ -28,7 +30,7 @@ version = "*"
 To build an image, use the build command. Specify the image type (e.g., `qcow2`, `ami`, `vmdk`), the distribution as `fedora-43`, and point to your local blueprint.
 
 ```
-$ sudo image-builder build qcow2 \
+$ image-builder build qcow2 \
   --distro fedora-43 \
   --blueprint fedora-43-base.toml \
   --output-dir ./build-output
@@ -51,6 +53,88 @@ You can verify the supported architectures and formats for Fedora 43 by using th
 
 ```
 $ image-builder list --filter distro:fedora-43
+```
+
+An image is specified by a blueprint and an image type. Unless you specify otherwise, it will use the same distribution and version (e.g. Fedora 39) as the host system. The architecture will always be the same as the one on the host.
+
+## Blueprints management using composer-cli
+
+`osbuild-composer` provides storage for blueprints. To store a `blueprint.toml` blueprint file, run this command:
+
+```
+$ composer-cli blueprints push blueprint.toml
+```
+
+To verify that the blueprint is available, list all currently stored blueprints:
+
+```
+$ composer-cli blueprints list
+base-image-with-tmux
+```
+To display the blueprint you have just added, run the command:
+
+```
+$ sudo composer-cli blueprints show base-image-with-tmux
+name = "base-image-with-tmux"
+description = "A base system with tmux"
+version = "0.0.1"
+modules = []
+groups = []
+
+[[packages]]
+name = "tmux"
+version = "*"
+```
+
+## Building an image using composer-cli
+
+To build a customized image, start by choosing the blueprint and image type you would like to build. To do so, run the following commands:
+
+```
+$ sudo composer-cli blueprints list
+$ sudo composer-cli compose types
+```
+
+and trigger a compose (example using the blueprint from the previous section):
+
+```
+$ composer-cli compose start base-image-with-tmux qcow2
+Compose ab71b61a-b3c4-434f-b214-1e16527766ff added to the queue
+```
+
+Note that the compose is assigned with a Universally Unique Identifier (UUID), that you can use to monitor the image build progress:
+
+```
+$ composer-cli compose info ab71b61a-b3c4-434f-b214-1e16527766ff
+ab71b61a-b3c4-434f-b214-1e16527766ff RUNNING  base-image-with-tmux 0.0.1 qcow2            2147483648
+Packages:
+    tmux-*
+Modules:
+Dependencies:
+```
+
+At this time, the compose is in a "RUNNING" state. Once the compose reaches the "FINISHED" state, you can download the resulting image by running the following command:
+
+```
+$ sudo composer-cli compose results ab71b61a-b3c4-434f-b214-1e16527766ff
+ab71b61a-b3c4-434f-b214-1e16527766ff.tar: 455.18 MB
+$ fd
+ab71b61a-b3c4-434f-b214-1e16527766ff.tar
+$ tar xf ab71b61a-b3c4-434f-b214-1e16527766ff.tar
+$ fd 
+ab71b61a-b3c4-434f-b214-1e16527766ff-disk.qcow2
+ab71b61a-b3c4-434f-b214-1e16527766ff.json
+ab71b61a-b3c4-434f-b214-1e16527766ff.tar
+logs
+logs/osbuild.log
+```
+
+From the example output above, the resulting tarball contains not only the `qcow2` image, but also a `JSON` file, which is the osbuild manifest (see the [Developer Guide](../../developer-guide/00-index.md) for more details), and a directory with logs.
+
+For more options, see the `help` text for `composer-cli`:
+
+```
+$ sudo composer-cli compose help
 ```
 
 #### Tip: Booting the image with qemu

--- a/docs/on-premises/02-commandline/index.md
+++ b/docs/on-premises/02-commandline/index.md
@@ -1,85 +1,56 @@
 # Using the commandline
 
-An image is specified by a blueprint and an image type. Unless you specify otherwise, it will use the same distribution and version (e.g. Fedora 39) as the host system. The architecture will always be the same as the one on the host.
+An image is specified by a blueprint and an image type. Unless you specify otherwise, it will use the same distribution and version (e.g. Fedora 43) as the host system. The architecture will always be the same as the one on the host.
 
-## Blueprints management using composer-cli
+## Create a blueprint
 
-`osbuild-composer` provides storage for blueprints. To store a `blueprint.toml` blueprint file, run this command:
 
-```
-$ composer-cli blueprints push blueprint.toml
-```
-
-To verify that the blueprint is available, list all currently stored blueprints:
+Create a `.toml` file: 
 
 ```
-$ composer-cli blueprints list
-base-image-with-tmux
+$ vim fedora-43-base.toml
 ```
-To display the blueprint you have just added, run the command:
+
+Define the details of the image in the `fedora-43-base.toml` file: 
 
 ```
-$ sudo composer-cli blueprints show base-image-with-tmux
-name = "base-image-with-tmux"
-description = "A base system with tmux"
+name = "fedora-43-custom"
+description = "A Fedora 43 base system with tmux"
 version = "0.0.1"
-modules = []
-groups = []
 
 [[packages]]
 name = "tmux"
 version = "*"
 ```
 
-## Building an image using composer-cli
+## Building an image 
 
-To build a customized image, start by choosing the blueprint and image type you would like to build. To do so, run the following commands:
-
-```
-$ sudo composer-cli blueprints list
-$ sudo composer-cli compose types
-```
-
-and trigger a compose (example using the blueprint from the previous section):
+To build an image, use the build command. Specify the image type (e.g., `qcow2`, `ami`, `vmdk`), the distribution as `fedora-43`, and point to your local blueprint.
 
 ```
-$ composer-cli compose start base-image-with-tmux qcow2
-Compose ab71b61a-b3c4-434f-b214-1e16527766ff added to the queue
+$ sudo image-builder build qcow2 \
+  --distro fedora-43 \
+  --blueprint fedora-43-base.toml \
+  --output-dir ./build-output
 ```
 
-Note that the compose is assigned with a Universally Unique Identifier (UUID), that you can use to monitor the image build progress:
+The process runs in your terminal and provides updates about the progress of the build. The finished image is placed directly in the `./build-output` directory.
 
 ```
-$ composer-cli compose info ab71b61a-b3c4-434f-b214-1e16527766ff
-ab71b61a-b3c4-434f-b214-1e16527766ff RUNNING  base-image-with-tmux 0.0.1 qcow2            2147483648
-Packages:
-    tmux-*
-Modules:
-Dependencies:
+[/] Image building step
+[6 / 6] Pipeline qcow2 [------------------------------------->] 100.00%
+[2 / 2] Stage org.osbuild.qemu [----------------------------->] 100.00%
+Message: Finished pipeline qcow2
+Image build successful, results:
+build-output/fedora-43-server-qcow2-aarch64.qcow2
 ```
 
-At this time, the compose is in a "RUNNING" state. Once the compose reaches the "FINISHED" state, you can download the resulting image by running the following command:
+## Reviewing Supported Targets
+
+You can verify the supported architectures and formats for Fedora 43 by using the list command:
 
 ```
-$ sudo composer-cli compose results ab71b61a-b3c4-434f-b214-1e16527766ff
-ab71b61a-b3c4-434f-b214-1e16527766ff.tar: 455.18 MB
-$ fd
-ab71b61a-b3c4-434f-b214-1e16527766ff.tar
-$ tar xf ab71b61a-b3c4-434f-b214-1e16527766ff.tar
-$ fd 
-ab71b61a-b3c4-434f-b214-1e16527766ff-disk.qcow2
-ab71b61a-b3c4-434f-b214-1e16527766ff.json
-ab71b61a-b3c4-434f-b214-1e16527766ff.tar
-logs
-logs/osbuild.log
-```
-
-From the example output above, the resulting tarball contains not only the `qcow2` image, but also a `JSON` file, which is the osbuild manifest (see the [Developer Guide](../../developer-guide/00-index.md) for more details), and a directory with logs.
-
-For more options, see the `help` text for `composer-cli`:
-
-```
-$ sudo composer-cli compose help
+$ image-builder list --filter distro:fedora-43
 ```
 
 #### Tip: Booting the image with qemu

--- a/docs/user-guide/00-introduction.md
+++ b/docs/user-guide/00-introduction.md
@@ -50,6 +50,14 @@ Image Builder can create images in multiple output formats shown in the followin
 
 To check the supported types, run the command:
 
+Using the `image-builder` CLI: 
+
+```
+$ image-builder list
+```
+
+Using the `composer-cli` CLI: 
+
 ```
 $ composer-cli compose types
 ```


### PR DESCRIPTION
Recently I walked through all the image-builder workflows.  Because the docs had the composer-cli steps, I used this and thought that image-builder CLI wasn't available. Then Justin Sherrill told me I could actually use image-builder CLI. 

From my perspective, using image-builder CLI was an immediate, positive improvement to the workflow.  It would be good for anyone interested to enjoy the image-builder CLI as soon as possible. 

I marked this as draft because I am worried about this section: 

https://github.com/osbuild/osbuild.github.io/compare/main...melcorr:osbuild.github.io:ibcli-doc-updates?expand=1#diff-69e48e37a22a2d556c2f023b7f62fbe1ed7ae365f0484fbecc7810dd5e715e42R58

Edit: I have included both sets of commands everywhere that I could test them. 

I was walking through the steps on a Fedora 43 VM in UTM on my Mac. I had no means with which to test the cloud options. 

To the best of my ability, this is now ready for review. Am happy to make any changes but this can be parked if people think it is too premature to merge at the moment. 