### PR TITLE
script: pull image-builder (HMS-10852)

### DIFF
--- a/scripts/pull_image-builder.py
+++ b/scripts/pull_image-builder.py
@@ -12,7 +12,7 @@ from utils import patch_md
 def main():
     root = pathlib.Path(__file__).parent.parent
 
-    base_url = "https://github.com/osbuild/image-builder-cli"
+    base_url = "https://github.com/osbuild/image-builder"
     with tempfile.TemporaryDirectory() as tmp:
         path = pathlib.Path(tmp)
 


### PR DESCRIPTION
Pull from the `image-builder` repository instead of from the `image-builder-cli` repository which is no longer used.