### PR TITLE
docs/user-guide: document part_type, part_label and part_uuid

### DIFF
--- a/docs/user-guide/07-partitioning.md
+++ b/docs/user-guide/07-partitioning.md
@@ -79,6 +79,9 @@ When using the [Disk customizations](01-blueprint-reference.md#disk), the partit
       - `subvolumes`: One or more subvolumes for the btrfs volume. Each subvolume supports the following properties:
         - `name`: The name of the subvolume, which also defines its location on the parent volume.
         - `mountpoint`: The mountpoint for the subvolume.
+  - `part_type`: The partition type to set in the partition table for this partition, regardless of its `type` above (optional). For GPT partition tables this is a type GUID, for example `4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709` to mark a partition as x86-64 root per the [Discoverable Partitions Specification](https://uapi-group.org/specifications/specs/discoverable_partitions_specification/); for DOS partition tables it is a two-digit hex type ID, for example `06`. If not set, the partition type is assigned automatically based on the mountpoint or the payload type.
+  - `part_label`: The partition label in the partition table entry (GPT partition tables only, optional). Note that this is distinct from `label` above, which is the filesystem label.
+  - `part_uuid`: The unique partition UUID in the partition table entry (GPT partition tables only, optional). Not to be confused with `part_type`, the type GUID.
 
 ### Order
 


### PR DESCRIPTION
The `part_type`, `part_label`, and `part_uuid` keys on disk partition customizations have been supported by the blueprint parser for a while (https://github.com/osbuild/blueprint/blob/v1.32.0/pkg/blueprint/disk_customizations.go#L78-L90), but I couldn't find them in the partitioning guide's property reference, and I only discovered `part_type` by reading the Go source. This adds all three, with the Discoverable Partitions Specification root GUID as the GPT example, since setting a discoverable root type is currently how a UKI/gpt-auto bootc image is made bootable from a blueprint (context: osbuild/image-builder#2337).

Wording is derived from the GoDoc on `PartitionCustomization`.
