### PR TITLE
Fix docs for FIPS, btrfs, partitioning_mode

### DIFF
--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1348,15 +1348,23 @@ in the repository configuration. **GPG keys are not imported to the RPM database
 
 _See the section of the guide on [Partitioning](./07-partitioning.md) for more details._
 
-The `customizations.partitioning_mode` variable can be used to select how the
-disk image will be partitioned. See the [Partitioning](./07-partitioning.md)
-guide for full semantics.
+The `customizations.partitioning_mode` variable controls how filesystem
+customizations change the image type’s **base** partition table. The base
+layout itself depends on the image type: some defaults are plain partitions,
+others already use LVM (for example Fedora Server) or Btrfs.
 
-Supported modes:
-- `auto-lvm` (default) uses raw unless [filesystem customizations](#filesystems) are included, in which case it uses LVM.
-- `raw` always uses raw partitions
-- `lvm` always uses LVM partitions
-- `btrfs` converts the root partition to a Btrfs volume (extra mountpoints become subvolumes; see [Partitioning](./07-partitioning.md))
+To see a type’s default, open its [image description](./09-image-descriptions/index.md)
+and inspect `partition_table` in the YAML (plain root shows a filesystem
+`payload` with a `mountpoint`; LVM shows `logical_volumes`).
+
+Not every image type accepts `partitioning_mode` / `filesystem` — check that
+page’s supported blueprint options list.
+
+Supported modes (when the image type allows them):
+- `auto-lvm` (default) — keep the image type’s base layout when you do not add new mountpoints; if the base is plain and the blueprint adds new mountpoints via [filesystems](#filesystems), convert to LVM
+- `raw` — keep plain partitions (never convert to LVM or Btrfs; unsupported if the base is already LVM)
+- `lvm` — always LVM
+- `btrfs` — always Btrfs for root (extra mountpoints become subvolumes; see [Partitioning](./07-partitioning.md))
 
 <Tabs values={tabValues} >
 <TabItem value="on-premises" >

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1302,12 +1302,14 @@ enabled=true
 {
   "customizations": {
     "custom_repositories": [
-      "id": "example",
-      "name": "Example repo",
-      "baseurl": [ "https://example.com/yum/download" ],
-      "check_gpg": true,
-      "gpgkey" : [ "https://example.com/public-key.asc" ],
-      "enabled": true
+      {
+        "id": "example",
+        "name": "Example repo",
+        "baseurl": [ "https://example.com/yum/download" ],
+        "check_gpg": true,
+        "gpgkey": [ "https://example.com/public-key.asc" ],
+        "enabled": true
+      }
     ]
   }
 }

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1347,15 +1347,14 @@ in the repository configuration. **GPG keys are not imported to the RPM database
 _See the section of the guide on [Partitioning](./07-partitioning.md) for more details._
 
 The `customizations.partitioning_mode` variable can be used to select how the
-disk image will be partitioned. `auto-lvm` will use raw unless there are one or
-more [filesystem customizations](#filesystems) in which case it will use LVM.
-`lvm` always uses LVM, even when there are no extra mountpoints. `raw` uses raw
-partitions even when there are one or more mountpoints.
+disk image will be partitioned. See the [Partitioning](./07-partitioning.md)
+guide for full semantics.
 
 Supported modes:
-- `auto-lvm` uses raw unless [filesystem customizations](#filesystems) are included.
+- `auto-lvm` (default) uses raw unless [filesystem customizations](#filesystems) are included, in which case it uses LVM.
 - `raw` always uses raw partitions
 - `lvm` always uses LVM partitions
+- `btrfs` converts the root partition to a Btrfs volume (extra mountpoints become subvolumes; see [Partitioning](./07-partitioning.md))
 
 <Tabs values={tabValues} >
 <TabItem value="on-premises" >

--- a/docs/user-guide/01-blueprint-reference.md
+++ b/docs/user-guide/01-blueprint-reference.md
@@ -1727,8 +1727,9 @@ data = "<json-tailoring-file-contents>"
 ### FIPS 🔵 🟤 {#fips}
 
 Enables/disables the system FIPS mode (disabled by default).
-Currently only `edge-raw-image`, `edge-installer`, `edge-simplified-installer`,
-`edge-ami` and `edge-vsphere` images support this customization.
+Support depends on the image type — check the [image description](./09-image-descriptions/index.md)
+`supported_options` list for `customizations.fips` (it is available on many
+common disk image types, not only Edge).
 
 <Tabs values={tabValues} >
 <TabItem value="on-premises" >


### PR DESCRIPTION
based on #209 
fixes docs for FIPS, btrfs and partitioning_mode

especially the `partitioning_mode` needs a review if this is better now…
in the `custom_repositories` json, I think there only was a typo.

setting to draft so we can merge them in-order.